### PR TITLE
add csv header to instance node

### DIFF
--- a/client/dimensions_api_test.go
+++ b/client/dimensions_api_test.go
@@ -1,17 +1,17 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"github.com/ONSdigital/dp-dimension-importer/mocks"
 	"github.com/ONSdigital/dp-dimension-importer/model"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
-	"github.com/ONSdigital/dp-dimension-importer/mocks"
-	"net/http"
 	"io"
-	"encoding/json"
-	"bytes"
 	"io/ioutil"
+	"net/http"
 	"reflect"
+	"testing"
 )
 
 const (
@@ -25,7 +25,276 @@ var dimensionOne = &model.Dimension{DimensionID: "666_SEX_MALE", NodeID: "1111",
 var dimensionTwo = &model.Dimension{DimensionID: "666_SEX_FEMALE", NodeID: "1112", Value: "Female"}
 var expectedDimensions = []*model.Dimension{dimensionOne, dimensionTwo}
 
+var expectedInstance = &model.Instance{InstanceID: instanceID, CSVHeader: []string{"the", "csv", "header"}}
+
 var body []byte
+
+func TestImportAPI_GetInstance_NotConfigured(t *testing.T) {
+
+	Convey("Given the client has not been configured", t, func() {
+		httpClientMock := &mocks.HTTPClientMock{}
+		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
+
+		// Set the host to an empty for this test case.
+		importAPI := ImportAPI{
+			ImportHost:         "",
+			HTTPClient:         httpClientMock,
+			ResponseBodyReader: respBodyReaderMock,
+		}
+
+		Convey("When the GetInstance is called", func() {
+			instance, err := importAPI.GetInstance(instanceID)
+
+			Convey("Then a nil instance and the appropriate error is returned.", func() {
+				So(instance, ShouldEqual, nil)
+				So(err, ShouldResemble, errors.New(hostConfigMissingErr))
+			})
+
+			Convey("And HTTPClient.Do and ResponseBodyReader.ReadAll are never called", func() {
+				So(len(httpClientMock.DoCalls()), ShouldEqual, 0)
+				So(len(respBodyReaderMock.ReadCalls()), ShouldEqual, 0)
+			})
+		})
+	})
+}
+
+func TestImportAPI_GetInstance(t *testing.T) {
+
+	Convey("Given valid client configuration", t, func() {
+		httpClientMock := &mocks.HTTPClientMock{}
+		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
+
+		body, _ = json.Marshal(expectedInstance)
+		reader := bytes.NewBuffer(body)
+		readCloser := ioutil.NopCloser(reader)
+
+		// set up mocks.
+		httpClientMock.DoFunc = func(req *http.Request) (*http.Response, error) {
+			return &http.Response{Body: readCloser, StatusCode: 200}, nil
+		}
+
+		respBodyReaderMock.ReadFunc = func(r io.Reader) ([]byte, error) {
+			return body, nil
+		}
+
+		importAPI := ImportAPI{
+			ImportHost:         "http://localhost:8080",
+			HTTPClient:         httpClientMock,
+			ResponseBodyReader: respBodyReaderMock,
+		}
+
+		Convey("When the GetInstance method is called", func() {
+
+			instance, err := importAPI.GetInstance(instanceID)
+
+			Convey("Then the expected response is returned with no error", func() {
+				So(instance, ShouldResemble, expectedInstance)
+				So(err, ShouldEqual, nil)
+			})
+
+			Convey("And HTTPClient.Do is called 1 time", func() {
+				So(len(httpClientMock.DoCalls()), ShouldEqual, 1)
+			})
+
+			Convey("And ResponseBodyReader.ReadAll is called 1 time with the expected parameters", func() {
+				calls := respBodyReaderMock.ReadCalls()
+				So(len(calls), ShouldEqual, 1)
+				So(calls[0].R, ShouldResemble, readCloser)
+			})
+		})
+	})
+}
+
+func TestImportAPI_GetInstance_EmptyInstanceID(t *testing.T) {
+
+	Convey("Given an empty instanceID", t, func() {
+
+		instanceID := ""
+
+		httpClientMock := &mocks.HTTPClientMock{}
+		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
+
+		importAPI := ImportAPI{
+			ImportHost:         "http://localhost:8080",
+			HTTPClient:         httpClientMock,
+			ResponseBodyReader: respBodyReaderMock,
+		}
+
+		Convey("When GetInstance is invoked", func() {
+
+			instance, err := importAPI.GetInstance(instanceID)
+
+			Convey("Then the expected error is returned", func() {
+				So(instance, ShouldEqual, nil)
+				So(err, ShouldResemble, errors.New(instanceIDRequiredErr))
+			})
+		})
+	})
+}
+
+func TestImportAPI_GetInstance_HTTPClientErr(t *testing.T) {
+
+	Convey("Given HTTPClient.Do will return an error", t, func() {
+
+		httpClientMock := &mocks.HTTPClientMock{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return nil, expectedErr
+			},
+		}
+		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
+
+		Convey("When GetInstance is invoked", func() {
+			importAPI := ImportAPI{
+				ImportHost:         "http://localhost:8080",
+				HTTPClient:         httpClientMock,
+				ResponseBodyReader: respBodyReaderMock,
+			}
+
+			instance, err := importAPI.GetInstance(instanceID)
+
+			Convey("Then the expected error response is returned", func() {
+				So(instance, ShouldEqual, nil)
+				So(err, ShouldResemble, expectedErr)
+			})
+
+			Convey("And HTTPClient.Do is called 1 time", func() {
+				So(len(httpClientMock.DoCalls()), ShouldEqual, 1)
+			})
+
+			Convey("And ResponseBodyReader.ReadAll is never called", func() {
+				So(len(respBodyReaderMock.ReadCalls()), ShouldEqual, 0)
+			})
+		})
+	})
+}
+
+func TestImportAPI_GetInstance_HTTPErrResponse(t *testing.T) {
+	Convey("Given HTTPClient.Do returns a non 200 response status", t, func() {
+		httpClientMock := &mocks.HTTPClientMock{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return Response([]byte{}, 400, nil)
+			},
+		}
+		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
+
+		Convey("When GetInstance is invoked", func() {
+			importAPI := ImportAPI{
+				ImportHost:         "http://localhost:8080",
+				HTTPClient:         httpClientMock,
+				ResponseBodyReader: respBodyReaderMock,
+			}
+
+			instance, err := importAPI.GetInstance(instanceID)
+
+			Convey("Then the expected error response is returned", func() {
+				So(instance, ShouldEqual, nil)
+				So(err, ShouldResemble, errors.New(getInstanceErr))
+			})
+
+			Convey("And HTTPClient.Do is called 1 time", func() {
+				So(len(httpClientMock.DoCalls()), ShouldEqual, 1)
+			})
+
+			Convey("And ResponseBodyReader.ReadAll is never called", func() {
+				So(len(respBodyReaderMock.ReadCalls()), ShouldEqual, 0)
+			})
+		})
+	})
+}
+
+func TestImportAPI_GetInstance_ResponseBodyErr(t *testing.T) {
+
+	Convey("Given ResponseBodyReader.ReadAll returns an error", t, func() {
+		body, _ = json.Marshal(expectedDimensions)
+		reader := bytes.NewBuffer(body)
+		readCloser := ioutil.NopCloser(reader)
+
+		httpClientMock := &mocks.HTTPClientMock{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return Response(body, 200, nil)
+			},
+		}
+		respBodyReaderMock := &mocks.ResponseBodyReaderMock{
+			ReadFunc: func(r io.Reader) ([]byte, error) {
+				return nil, expectedErr
+			},
+		}
+
+		Convey("When GetInstance is invoked", func() {
+			importAPI := ImportAPI{
+				ImportHost:         "http://localhost:8080",
+				HTTPClient:         httpClientMock,
+				ResponseBodyReader: respBodyReaderMock,
+			}
+
+			instance, err := importAPI.GetInstance(instanceID)
+
+			Convey("Then the expected error response is returned", func() {
+				So(instance, ShouldEqual, nil)
+				So(err, ShouldResemble, expectedErr)
+			})
+
+			Convey("And HTTPClient.Do is called 1 time", func() {
+				So(len(httpClientMock.DoCalls()), ShouldEqual, 1)
+			})
+
+			Convey("And ResponseBodyReader.ReadAll is called 1 time with the expected parameters", func() {
+				calls := respBodyReaderMock.ReadCalls()
+				So(len(calls), ShouldEqual, 1)
+				So(calls[0].R, ShouldResemble, readCloser)
+			})
+		})
+	})
+}
+
+func TestImportAPI_GetInstance_UnmarshalErr(t *testing.T) {
+
+	Convey("Given unmarshalling the response body returns an error", t, func() {
+
+		body := []byte("INVALID INSTANCE BYTES")
+		reader := bytes.NewBuffer(body)
+		readCloser := ioutil.NopCloser(reader)
+
+		httpClientMock := &mocks.HTTPClientMock{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return Response(body, 200, nil)
+			},
+		}
+		respBodyReaderMock := &mocks.ResponseBodyReaderMock{
+			ReadFunc: func(r io.Reader) ([]byte, error) {
+				return body, nil
+			},
+		}
+
+		Convey("When GetInstance is invoked", func() {
+			importAPI := ImportAPI{
+				ImportHost:         "http://localhost:8080",
+				HTTPClient:         httpClientMock,
+				ResponseBodyReader: respBodyReaderMock,
+			}
+
+			instance, err := importAPI.GetInstance(instanceID)
+
+			Convey("Then the expected error response is returned", func() {
+				expectedType := reflect.TypeOf((*json.SyntaxError)(nil))
+				actualType := reflect.TypeOf(err)
+
+				So(actualType, ShouldEqual, expectedType)
+				So(instance, ShouldEqual, nil)
+			})
+
+			Convey("And HTTPClient.Do is called 1 time", func() {
+				So(len(httpClientMock.DoCalls()), ShouldEqual, 1)
+			})
+
+			Convey("And ResponseBodyReader.ReadAll is called 1 time with the expected parameters", func() {
+				calls := respBodyReaderMock.ReadCalls()
+				So(len(calls), ShouldEqual, 1)
+				So(calls[0].R, ShouldResemble, readCloser)
+			})
+		})
+	})
+}
 
 func TestGetDimensions(t *testing.T) {
 

--- a/mocks/dimensions_extracted_generated_mocks.go
+++ b/mocks/dimensions_extracted_generated_mocks.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	lockImportAPIClientMockGetDimensions      sync.RWMutex
+	lockImportAPIClientMockGetInstance        sync.RWMutex
 	lockImportAPIClientMockPutDimensionNodeID sync.RWMutex
 )
 
@@ -21,6 +22,9 @@ var (
 //         mockedImportAPIClient := &ImportAPIClientMock{
 //             GetDimensionsFunc: func(instanceID string) ([]*model.Dimension, error) {
 // 	               panic("TODO: mock out the GetDimensions method")
+//             },
+//             GetInstanceFunc: func(instanceID string) (*model.Instance, error) {
+// 	               panic("TODO: mock out the GetInstance method")
 //             },
 //             PutDimensionNodeIDFunc: func(instanceID string, dimension *model.Dimension) error {
 // 	               panic("TODO: mock out the PutDimensionNodeID method")
@@ -35,6 +39,9 @@ type ImportAPIClientMock struct {
 	// GetDimensionsFunc mocks the GetDimensions method.
 	GetDimensionsFunc func(instanceID string) ([]*model.Dimension, error)
 
+	// GetInstanceFunc mocks the GetInstance method.
+	GetInstanceFunc func(instanceID string) (*model.Instance, error)
+
 	// PutDimensionNodeIDFunc mocks the PutDimensionNodeID method.
 	PutDimensionNodeIDFunc func(instanceID string, dimension *model.Dimension) error
 
@@ -42,6 +49,11 @@ type ImportAPIClientMock struct {
 	calls struct {
 		// GetDimensions holds details about calls to the GetDimensions method.
 		GetDimensions []struct {
+			// InstanceID is the instanceID argument value.
+			InstanceID string
+		}
+		// GetInstance holds details about calls to the GetInstance method.
+		GetInstance []struct {
 			// InstanceID is the instanceID argument value.
 			InstanceID string
 		}
@@ -83,6 +95,37 @@ func (mock *ImportAPIClientMock) GetDimensionsCalls() []struct {
 	lockImportAPIClientMockGetDimensions.RLock()
 	calls = mock.calls.GetDimensions
 	lockImportAPIClientMockGetDimensions.RUnlock()
+	return calls
+}
+
+// GetInstance calls GetInstanceFunc.
+func (mock *ImportAPIClientMock) GetInstance(instanceID string) (*model.Instance, error) {
+	if mock.GetInstanceFunc == nil {
+		panic("moq: ImportAPIClientMock.GetInstanceFunc is nil but ImportAPIClient.GetInstance was just called")
+	}
+	callInfo := struct {
+		InstanceID string
+	}{
+		InstanceID: instanceID,
+	}
+	lockImportAPIClientMockGetInstance.Lock()
+	mock.calls.GetInstance = append(mock.calls.GetInstance, callInfo)
+	lockImportAPIClientMockGetInstance.Unlock()
+	return mock.GetInstanceFunc(instanceID)
+}
+
+// GetInstanceCalls gets all the calls that were made to GetInstance.
+// Check the length with:
+//     len(mockedImportAPIClient.GetInstanceCalls())
+func (mock *ImportAPIClientMock) GetInstanceCalls() []struct {
+	InstanceID string
+} {
+	var calls []struct {
+		InstanceID string
+	}
+	lockImportAPIClientMockGetInstance.RLock()
+	calls = mock.calls.GetInstance
+	lockImportAPIClientMockGetInstance.RUnlock()
 	return calls
 }
 

--- a/model/models.go
+++ b/model/models.go
@@ -41,7 +41,8 @@ func (d *Dimension) GetName(instanceID string) string {
 
 // Instance struct to hold instance information.
 type Instance struct {
-	InstanceID string
+	InstanceID string   `json:"instance_id,omitempty"`
+	CSVHeader  []string `json:"headers"`
 	Dimensions []interface{}
 }
 
@@ -58,4 +59,9 @@ func (i *Instance) AddDimension(d *Dimension) {
 // GetDimensions returns a slice of distinct dimensions name/types for this instance.
 func (i *Instance) GetDimensions() []interface{} {
 	return i.Dimensions
+}
+
+// GetHeader returns the value of each cell in the CSV header.
+func (i *Instance) GetHeader() []string {
+	return i.CSVHeader
 }


### PR DESCRIPTION
### What

The CSV header is required to create filtered output files. The CSV header is read from the import API and added to the instance node.

### How to review

Check the code changes.

### Who can review

Mainly @daiLlew but anyone who fancies a look 😃 
