### PR TITLE
Change calls to the import API to use the updated dataset API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ dp-dimension-importer
 | -------------------------- | ------------------------------------ | -----------
 | BIND_ADDR                  | :21000                               | The host and port to bind to
 | KAFKA_ADDR                 | localhost:9092                       | The list of kafka hosts
-| IMPORT_ADDR                | http://localhost:21800               | The address of the import API
-| IMPORT_AUTH_TOKEN          | FD0108EA-825D-411C-9B1D-41EF7727F465 | The authentication token for the import API
+| DATASET_API_ADDR           | http://localhost:21800               | The address of the dataset API
+| DATASET_API_AUTH_TOKEN     | FD0108EA-825D-411C-9B1D-41EF7727F465 | The authentication token for the dataset API
 | DB_URL                     | bolt://localhost:7687                | The URL of the database
 | DB_POOL_SIZE               | 20                                   | The number of database connections to maintain in a pool
 | DIMENSIONS_EXTRACTED_TOPIC | dimensions-extracted                 | The topic to consume messages from to when dimensions are extracted

--- a/client/dimensions_api.go
+++ b/client/dimensions_api.go
@@ -17,16 +17,16 @@ import (
 
 const (
 	unmarshallingErr      = "unexpected error while unmarshalling response"
-	unexpectedAPIErr      = "unexpected error returned when calling import api"
+	unexpectedAPIErr      = "unexpected error returned when calling dataset api"
 	hostConfigMissingErr  = "dimensions client requires an api host to be configured"
 	instanceIDRequiredErr = "instance id is required but is empty"
 
 	getInstanceURIFMT  = "%s/instances/%s"
-	getInstanceSuccess = "import api get instance success"
+	getInstanceSuccess = "dataset api get instance success"
 	getInstanceErr     = "get instance returned error status"
 
 	getDimensionsURIFMT  = "%s/instances/%s/dimensions"
-	getDimensionsSuccess = "import api get dimensions success"
+	getDimensionsSuccess = "dataset api get dimensions success"
 	getDimensionsErr     = "get dimensions returned error status"
 
 	createPutNodeIDReqErr = "unexpected error creating request struct"
@@ -35,8 +35,8 @@ const (
 	putDimNodeIDErr       = "set dimension node id returned error status"
 	dimensionNilErr       = "dimension is required but was nil"
 	dimensionIDReqErr     = "dimension id is required but was empty"
-	unauthorisedResponse  = "import api returned unauthorized response status"
-	forbiddenResponse     = "import api returned forbidden response status"
+	unauthorisedResponse  = "dataset api returned unauthorized response status"
+	forbiddenResponse     = "dataset api returned forbidden response status"
 	authTokenHeader       = "Internal-Token"
 	readRespBodyErr       = "unexpected error while attempting to read response body"
 	newReqErr             = "unexpected error while attempting to create new http request"
@@ -52,18 +52,18 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// ImportAPI provides methods for getting dimensions for a given instanceID and updating the node_id of a specific dimension.
-type ImportAPI struct {
-	ImportHost         string
-	AuthToken          string
-	ResponseBodyReader ResponseBodyReader
-	HTTPClient         HTTPClient
+// DatasetAPI provides methods for getting dimensions for a given instanceID and updating the node_id of a specific dimension.
+type DatasetAPI struct {
+	DatasetAPIHost      string
+	DatasetAPIAuthToken string
+	ResponseBodyReader  ResponseBodyReader
+	HTTPClient          HTTPClient
 }
 
 // GetInstance returns instance data from the import API.
-func (api ImportAPI) GetInstance(instanceID string) (*model.Instance, error) {
+func (api DatasetAPI) GetInstance(instanceID string) (*model.Instance, error) {
 
-	if len(api.ImportHost) == 0 {
+	if len(api.DatasetAPIHost) == 0 {
 		err := errors.New(hostConfigMissingErr)
 		log.ErrorC(hostConfigMissingErr, err, nil)
 		return nil, err
@@ -73,7 +73,7 @@ func (api ImportAPI) GetInstance(instanceID string) (*model.Instance, error) {
 		return nil, errors.New(instanceIDRequiredErr)
 	}
 
-	url := fmt.Sprintf(getInstanceURIFMT, api.ImportHost, instanceID)
+	url := fmt.Sprintf(getInstanceURIFMT, api.DatasetAPIHost, instanceID)
 	data := log.Data{
 		logKeys.InstanceID: instanceID,
 		logKeys.URL:        url,
@@ -118,8 +118,8 @@ func (api ImportAPI) GetInstance(instanceID string) (*model.Instance, error) {
 }
 
 // GetDimensions perform a HTTP GET request to the dp-import-api to retrieve the dataset dimenions for the specified instanceID
-func (api ImportAPI) GetDimensions(instanceID string) ([]*model.Dimension, error) {
-	if len(api.ImportHost) == 0 {
+func (api DatasetAPI) GetDimensions(instanceID string) ([]*model.Dimension, error) {
+	if len(api.DatasetAPIHost) == 0 {
 		err := errors.New(hostConfigMissingErr)
 		log.ErrorC(hostConfigMissingErr, err, nil)
 		return nil, err
@@ -128,7 +128,7 @@ func (api ImportAPI) GetDimensions(instanceID string) ([]*model.Dimension, error
 		return nil, errors.New(instanceIDRequiredErr)
 	}
 
-	url := fmt.Sprintf(getDimensionsURIFMT, api.ImportHost, instanceID)
+	url := fmt.Sprintf(getDimensionsURIFMT, api.DatasetAPIHost, instanceID)
 	data := log.Data{
 		logKeys.InstanceID: instanceID,
 		logKeys.URL:        url,
@@ -177,8 +177,8 @@ func (api ImportAPI) GetDimensions(instanceID string) ([]*model.Dimension, error
 }
 
 // PutDimensionNodeID make a HTTP put request to update the node_id of the specified dimension.
-func (api ImportAPI) PutDimensionNodeID(instanceID string, d *model.Dimension) error {
-	if len(api.ImportHost) == 0 {
+func (api DatasetAPI) PutDimensionNodeID(instanceID string, d *model.Dimension) error {
+	if len(api.DatasetAPIHost) == 0 {
 		err := errors.New(hostConfigMissingErr)
 		log.ErrorC(hostConfigMissingErr, err, nil)
 		return err
@@ -198,7 +198,7 @@ func (api ImportAPI) PutDimensionNodeID(instanceID string, d *model.Dimension) e
 	logData[logKeys.DimensionsKey] = d.DimensionID
 	logData[logKeys.NodeID] = d.NodeID
 
-	url := fmt.Sprintf(putDimensionNodeIDURI, api.ImportHost, instanceID, d.DimensionID, url.PathEscape(d.Value), d.NodeID)
+	url := fmt.Sprintf(putDimensionNodeIDURI, api.DatasetAPIHost, instanceID, d.DimensionID, url.PathEscape(d.Value), d.NodeID)
 	logData[logKeys.URL] = url
 
 	req, err := http.NewRequest(http.MethodPut, url, nil)
@@ -207,7 +207,7 @@ func (api ImportAPI) PutDimensionNodeID(instanceID string, d *model.Dimension) e
 		log.ErrorC(createPutNodeIDReqErr, err, logData)
 		return err
 	}
-	req.Header.Set(authTokenHeader, api.AuthToken)
+	req.Header.Set(authTokenHeader, api.DatasetAPIAuthToken)
 	resp, err := api.HTTPClient.Do(req)
 	if err != nil {
 		logData[logKeys.ErrorDetails] = err.Error()

--- a/client/dimensions_api_test.go
+++ b/client/dimensions_api_test.go
@@ -29,21 +29,21 @@ var expectedInstance = &model.Instance{InstanceID: instanceID, CSVHeader: []stri
 
 var body []byte
 
-func TestImportAPI_GetInstance_NotConfigured(t *testing.T) {
+func TestDatasetAPI_GetInstance_NotConfigured(t *testing.T) {
 
 	Convey("Given the client has not been configured", t, func() {
 		httpClientMock := &mocks.HTTPClientMock{}
 		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
 
 		// Set the host to an empty for this test case.
-		importAPI := ImportAPI{
-			ImportHost:         "",
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost:     "",
 			HTTPClient:         httpClientMock,
 			ResponseBodyReader: respBodyReaderMock,
 		}
 
 		Convey("When the GetInstance is called", func() {
-			instance, err := importAPI.GetInstance(instanceID)
+			instance, err := datasetAPI.GetInstance(instanceID)
 
 			Convey("Then a nil instance and the appropriate error is returned.", func() {
 				So(instance, ShouldEqual, nil)
@@ -58,7 +58,7 @@ func TestImportAPI_GetInstance_NotConfigured(t *testing.T) {
 	})
 }
 
-func TestImportAPI_GetInstance(t *testing.T) {
+func TestDatasetAPI_GetInstance(t *testing.T) {
 
 	Convey("Given valid client configuration", t, func() {
 		httpClientMock := &mocks.HTTPClientMock{}
@@ -77,15 +77,15 @@ func TestImportAPI_GetInstance(t *testing.T) {
 			return body, nil
 		}
 
-		importAPI := ImportAPI{
-			ImportHost:         "http://localhost:8080",
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost:     "http://localhost:8080",
 			HTTPClient:         httpClientMock,
 			ResponseBodyReader: respBodyReaderMock,
 		}
 
 		Convey("When the GetInstance method is called", func() {
 
-			instance, err := importAPI.GetInstance(instanceID)
+			instance, err := datasetAPI.GetInstance(instanceID)
 
 			Convey("Then the expected response is returned with no error", func() {
 				So(instance, ShouldResemble, expectedInstance)
@@ -105,7 +105,7 @@ func TestImportAPI_GetInstance(t *testing.T) {
 	})
 }
 
-func TestImportAPI_GetInstance_EmptyInstanceID(t *testing.T) {
+func TestDatasetAPI_GetInstance_EmptyInstanceID(t *testing.T) {
 
 	Convey("Given an empty instanceID", t, func() {
 
@@ -114,15 +114,15 @@ func TestImportAPI_GetInstance_EmptyInstanceID(t *testing.T) {
 		httpClientMock := &mocks.HTTPClientMock{}
 		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
 
-		importAPI := ImportAPI{
-			ImportHost:         "http://localhost:8080",
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost:     "http://localhost:8080",
 			HTTPClient:         httpClientMock,
 			ResponseBodyReader: respBodyReaderMock,
 		}
 
 		Convey("When GetInstance is invoked", func() {
 
-			instance, err := importAPI.GetInstance(instanceID)
+			instance, err := datasetAPI.GetInstance(instanceID)
 
 			Convey("Then the expected error is returned", func() {
 				So(instance, ShouldEqual, nil)
@@ -132,7 +132,7 @@ func TestImportAPI_GetInstance_EmptyInstanceID(t *testing.T) {
 	})
 }
 
-func TestImportAPI_GetInstance_HTTPClientErr(t *testing.T) {
+func TestDatasetAPI_GetInstance_HTTPClientErr(t *testing.T) {
 
 	Convey("Given HTTPClient.Do will return an error", t, func() {
 
@@ -144,13 +144,13 @@ func TestImportAPI_GetInstance_HTTPClientErr(t *testing.T) {
 		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
 
 		Convey("When GetInstance is invoked", func() {
-			importAPI := ImportAPI{
-				ImportHost:         "http://localhost:8080",
+			datasetAPI := DatasetAPI{
+				DatasetAPIHost:     "http://localhost:8080",
 				HTTPClient:         httpClientMock,
 				ResponseBodyReader: respBodyReaderMock,
 			}
 
-			instance, err := importAPI.GetInstance(instanceID)
+			instance, err := datasetAPI.GetInstance(instanceID)
 
 			Convey("Then the expected error response is returned", func() {
 				So(instance, ShouldEqual, nil)
@@ -168,7 +168,7 @@ func TestImportAPI_GetInstance_HTTPClientErr(t *testing.T) {
 	})
 }
 
-func TestImportAPI_GetInstance_HTTPErrResponse(t *testing.T) {
+func TestDatasetAPI_GetInstance_HTTPErrResponse(t *testing.T) {
 	Convey("Given HTTPClient.Do returns a non 200 response status", t, func() {
 		httpClientMock := &mocks.HTTPClientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -178,13 +178,13 @@ func TestImportAPI_GetInstance_HTTPErrResponse(t *testing.T) {
 		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
 
 		Convey("When GetInstance is invoked", func() {
-			importAPI := ImportAPI{
-				ImportHost:         "http://localhost:8080",
+			datasetAPI := DatasetAPI{
+				DatasetAPIHost:     "http://localhost:8080",
 				HTTPClient:         httpClientMock,
 				ResponseBodyReader: respBodyReaderMock,
 			}
 
-			instance, err := importAPI.GetInstance(instanceID)
+			instance, err := datasetAPI.GetInstance(instanceID)
 
 			Convey("Then the expected error response is returned", func() {
 				So(instance, ShouldEqual, nil)
@@ -202,7 +202,7 @@ func TestImportAPI_GetInstance_HTTPErrResponse(t *testing.T) {
 	})
 }
 
-func TestImportAPI_GetInstance_ResponseBodyErr(t *testing.T) {
+func TestDatasetAPI_GetInstance_ResponseBodyErr(t *testing.T) {
 
 	Convey("Given ResponseBodyReader.ReadAll returns an error", t, func() {
 		body, _ = json.Marshal(expectedDimensions)
@@ -221,13 +221,13 @@ func TestImportAPI_GetInstance_ResponseBodyErr(t *testing.T) {
 		}
 
 		Convey("When GetInstance is invoked", func() {
-			importAPI := ImportAPI{
-				ImportHost:         "http://localhost:8080",
+			datasetAPI := DatasetAPI{
+				DatasetAPIHost:     "http://localhost:8080",
 				HTTPClient:         httpClientMock,
 				ResponseBodyReader: respBodyReaderMock,
 			}
 
-			instance, err := importAPI.GetInstance(instanceID)
+			instance, err := datasetAPI.GetInstance(instanceID)
 
 			Convey("Then the expected error response is returned", func() {
 				So(instance, ShouldEqual, nil)
@@ -247,7 +247,7 @@ func TestImportAPI_GetInstance_ResponseBodyErr(t *testing.T) {
 	})
 }
 
-func TestImportAPI_GetInstance_UnmarshalErr(t *testing.T) {
+func TestDatasetAPI_GetInstance_UnmarshalErr(t *testing.T) {
 
 	Convey("Given unmarshalling the response body returns an error", t, func() {
 
@@ -267,13 +267,13 @@ func TestImportAPI_GetInstance_UnmarshalErr(t *testing.T) {
 		}
 
 		Convey("When GetInstance is invoked", func() {
-			importAPI := ImportAPI{
-				ImportHost:         "http://localhost:8080",
+			datasetAPI := DatasetAPI{
+				DatasetAPIHost:     "http://localhost:8080",
 				HTTPClient:         httpClientMock,
 				ResponseBodyReader: respBodyReaderMock,
 			}
 
-			instance, err := importAPI.GetInstance(instanceID)
+			instance, err := datasetAPI.GetInstance(instanceID)
 
 			Convey("Then the expected error response is returned", func() {
 				expectedType := reflect.TypeOf((*json.SyntaxError)(nil))
@@ -303,14 +303,14 @@ func TestGetDimensions(t *testing.T) {
 		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
 
 		// Set the host to an empty for this test case.
-		importAPI := ImportAPI{
-			ImportHost:         "",
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost:     "",
 			HTTPClient:         httpClientMock,
 			ResponseBodyReader: respBodyReaderMock,
 		}
 
 		Convey("When the Get is invoked", func() {
-			dims, err := importAPI.GetDimensions(instanceID)
+			dims, err := datasetAPI.GetDimensions(instanceID)
 
 			Convey("Then no dimenions and the appropriate error are returned.", func() {
 				So(err, ShouldResemble, errors.New(hostConfigMissingErr))
@@ -342,13 +342,13 @@ func TestGetDimensions(t *testing.T) {
 				return body, nil
 			}
 
-			importAPI := ImportAPI{
-				ImportHost:         "http://localhost:8080",
+			datasetAPI := DatasetAPI{
+				DatasetAPIHost:     "http://localhost:8080",
 				HTTPClient:         httpClientMock,
 				ResponseBodyReader: respBodyReaderMock,
 			}
 
-			dims, err := importAPI.GetDimensions(instanceID)
+			dims, err := datasetAPI.GetDimensions(instanceID)
 
 			Convey("Then the expected response is returned with no error", func() {
 				So(dims, ShouldResemble, expectedDimensions)
@@ -372,13 +372,13 @@ func TestGetDimensions(t *testing.T) {
 		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
 
 		Convey("When GetDimensions is invoked", func() {
-			importAPI := ImportAPI{
-				ImportHost:         "http://localhost:8080",
+			datasetAPI := DatasetAPI{
+				DatasetAPIHost:     "http://localhost:8080",
 				HTTPClient:         httpClientMock,
 				ResponseBodyReader: respBodyReaderMock,
 			}
 
-			dims, err := importAPI.GetDimensions("")
+			dims, err := datasetAPI.GetDimensions("")
 
 			Convey("Then the expected error is returned", func() {
 				So(dims, ShouldEqual, nil)
@@ -396,13 +396,13 @@ func TestGetDimensions(t *testing.T) {
 		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
 
 		Convey("When GetDimensions is invoked", func() {
-			importAPI := ImportAPI{
-				ImportHost:         "http://localhost:8080",
+			datasetAPI := DatasetAPI{
+				DatasetAPIHost:     "http://localhost:8080",
 				HTTPClient:         httpClientMock,
 				ResponseBodyReader: respBodyReaderMock,
 			}
 
-			dims, err := importAPI.GetDimensions(instanceID)
+			dims, err := datasetAPI.GetDimensions(instanceID)
 
 			Convey("Then the expected error response is returned", func() {
 				So(dims, ShouldEqual, nil)
@@ -428,13 +428,13 @@ func TestGetDimensions(t *testing.T) {
 		respBodyReaderMock := &mocks.ResponseBodyReaderMock{}
 
 		Convey("When GetDimensions is invoked", func() {
-			importAPI := ImportAPI{
-				ImportHost:         "http://localhost:8080",
+			datasetAPI := DatasetAPI{
+				DatasetAPIHost:     "http://localhost:8080",
 				HTTPClient:         httpClientMock,
 				ResponseBodyReader: respBodyReaderMock,
 			}
 
-			dims, err := importAPI.GetDimensions(instanceID)
+			dims, err := datasetAPI.GetDimensions(instanceID)
 
 			Convey("Then the expected error response is returned", func() {
 				So(dims, ShouldEqual, nil)
@@ -468,13 +468,13 @@ func TestGetDimensions(t *testing.T) {
 		}
 
 		Convey("When GetDimensions is invoked", func() {
-			importAPI := ImportAPI{
-				ImportHost:         "http://localhost:8080",
+			datasetAPI := DatasetAPI{
+				DatasetAPIHost:     "http://localhost:8080",
 				HTTPClient:         httpClientMock,
 				ResponseBodyReader: respBodyReaderMock,
 			}
 
-			dims, err := importAPI.GetDimensions(instanceID)
+			dims, err := datasetAPI.GetDimensions(instanceID)
 
 			Convey("Then the expected error response is returned", func() {
 				So(dims, ShouldEqual, nil)
@@ -510,13 +510,13 @@ func TestGetDimensions(t *testing.T) {
 		}
 
 		Convey("When GetDimensions is invoked", func() {
-			importAPI := ImportAPI{
-				ImportHost:         "http://localhost:8080",
+			datasetAPI := DatasetAPI{
+				DatasetAPIHost:     "http://localhost:8080",
 				HTTPClient:         httpClientMock,
 				ResponseBodyReader: respBodyReaderMock,
 			}
 
-			dims, err := importAPI.GetDimensions(instanceID)
+			dims, err := datasetAPI.GetDimensions(instanceID)
 
 			Convey("Then the expected error response is returned", func() {
 				expectedType := reflect.TypeOf((*json.SyntaxError)(nil))
@@ -539,19 +539,19 @@ func TestGetDimensions(t *testing.T) {
 	})
 }
 
-func TestImportAPI_PutDimensionNodeID(t *testing.T) {
+func TestDatasetAPI_PutDimensionNodeID(t *testing.T) {
 	// mocks
 
-	Convey("Given importAPI.Host has not been set", t, func() {
+	Convey("Given datasetAPI.Host has not been set", t, func() {
 		httpCliMock := &mocks.HTTPClientMock{}
 
-		importAPI := ImportAPI{
-			ImportHost: "",
-			HTTPClient: httpCliMock,
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost: "",
+			HTTPClient:     httpCliMock,
 		}
 
 		Convey("When PutDimensionNodeID is called", func() {
-			err := importAPI.PutDimensionNodeID(instanceID, dimensionOne)
+			err := datasetAPI.PutDimensionNodeID(instanceID, dimensionOne)
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldResemble, errors.New(hostConfigMissingErr))
@@ -567,13 +567,13 @@ func TestImportAPI_PutDimensionNodeID(t *testing.T) {
 	Convey("Given no instanceID is provided", t, func() {
 		httpCliMock := &mocks.HTTPClientMock{}
 
-		importAPI := ImportAPI{
-			ImportHost: host,
-			HTTPClient: httpCliMock,
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost: host,
+			HTTPClient:     httpCliMock,
 		}
 
 		Convey("When PutDimensionNodeID is called", func() {
-			err := importAPI.PutDimensionNodeID("", dimensionOne)
+			err := datasetAPI.PutDimensionNodeID("", dimensionOne)
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldResemble, errors.New(instanceIDRequiredErr))
@@ -589,13 +589,13 @@ func TestImportAPI_PutDimensionNodeID(t *testing.T) {
 	Convey("Given no dimension is provided", t, func() {
 		httpCliMock := &mocks.HTTPClientMock{}
 
-		importAPI := ImportAPI{
-			ImportHost: host,
-			HTTPClient: httpCliMock,
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost: host,
+			HTTPClient:     httpCliMock,
 		}
 
 		Convey("When PutDimensionNodeID is called", func() {
-			err := importAPI.PutDimensionNodeID(instanceID, nil)
+			err := datasetAPI.PutDimensionNodeID(instanceID, nil)
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldResemble, errors.New(dimensionNilErr))
@@ -611,13 +611,13 @@ func TestImportAPI_PutDimensionNodeID(t *testing.T) {
 	Convey("Given a dimension with an empty dimensionID", t, func() {
 		httpCliMock := &mocks.HTTPClientMock{}
 
-		importAPI := ImportAPI{
-			ImportHost: host,
-			HTTPClient: httpCliMock,
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost: host,
+			HTTPClient:     httpCliMock,
 		}
 
 		Convey("When PutDimensionNodeID is called", func() {
-			err := importAPI.PutDimensionNodeID(instanceID, &model.Dimension{})
+			err := datasetAPI.PutDimensionNodeID(instanceID, &model.Dimension{})
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldResemble, errors.New(dimensionIDReqErr))
@@ -633,17 +633,17 @@ func TestImportAPI_PutDimensionNodeID(t *testing.T) {
 	Convey("Given HTTPClient.Do returns an error", t, func() {
 		httpCliMock := &mocks.HTTPClientMock{}
 
-		importAPI := ImportAPI{
-			ImportHost: host,
-			HTTPClient: httpCliMock,
-			AuthToken:  authToken,
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost:      host,
+			HTTPClient:          httpCliMock,
+			DatasetAPIAuthToken: authToken,
 		}
 		httpCliMock.DoFunc = func(req *http.Request) (*http.Response, error) {
 			return nil, expectedErr
 		}
 
 		Convey("When PutDimensionNodeID is called", func() {
-			err := importAPI.PutDimensionNodeID(instanceID, dimensionOne)
+			err := datasetAPI.PutDimensionNodeID(instanceID, dimensionOne)
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldResemble, expectedErr)
@@ -665,17 +665,17 @@ func TestImportAPI_PutDimensionNodeID(t *testing.T) {
 	Convey("Given HTTPClient.Do returns an 401 status", t, func() {
 		httpCliMock := &mocks.HTTPClientMock{}
 
-		importAPI := ImportAPI{
-			ImportHost: host,
-			HTTPClient: httpCliMock,
-			AuthToken:  authToken,
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost:      host,
+			HTTPClient:          httpCliMock,
+			DatasetAPIAuthToken: authToken,
 		}
 		httpCliMock.DoFunc = func(req *http.Request) (*http.Response, error) {
 			return Response([]byte{}, 401, nil)
 		}
 
 		Convey("When PutDimensionNodeID is called", func() {
-			err := importAPI.PutDimensionNodeID(instanceID, dimensionOne)
+			err := datasetAPI.PutDimensionNodeID(instanceID, dimensionOne)
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldResemble, errors.New(unauthorisedResponse))
@@ -691,17 +691,17 @@ func TestImportAPI_PutDimensionNodeID(t *testing.T) {
 	Convey("Given HTTPClient.Do returns an 403 status", t, func() {
 		httpCliMock := &mocks.HTTPClientMock{}
 
-		importAPI := ImportAPI{
-			ImportHost: host,
-			HTTPClient: httpCliMock,
-			AuthToken:  authToken,
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost:      host,
+			HTTPClient:          httpCliMock,
+			DatasetAPIAuthToken: authToken,
 		}
 		httpCliMock.DoFunc = func(req *http.Request) (*http.Response, error) {
 			return Response([]byte{}, 403, nil)
 		}
 
 		Convey("When PutDimensionNodeID is called", func() {
-			err := importAPI.PutDimensionNodeID(instanceID, dimensionOne)
+			err := datasetAPI.PutDimensionNodeID(instanceID, dimensionOne)
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldResemble, errors.New(forbiddenResponse))
@@ -717,17 +717,17 @@ func TestImportAPI_PutDimensionNodeID(t *testing.T) {
 	Convey("Given HTTPClient.Do returns an unexpected status", t, func() {
 		httpCliMock := &mocks.HTTPClientMock{}
 
-		importAPI := ImportAPI{
-			ImportHost: host,
-			HTTPClient: httpCliMock,
-			AuthToken:  authToken,
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost:      host,
+			HTTPClient:          httpCliMock,
+			DatasetAPIAuthToken: authToken,
 		}
 		httpCliMock.DoFunc = func(req *http.Request) (*http.Response, error) {
 			return Response([]byte{}, 500, nil)
 		}
 
 		Convey("When PutDimensionNodeID is called", func() {
-			err := importAPI.PutDimensionNodeID(instanceID, dimensionOne)
+			err := datasetAPI.PutDimensionNodeID(instanceID, dimensionOne)
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldResemble, errors.New(putDimNodeIDErr))
@@ -743,17 +743,17 @@ func TestImportAPI_PutDimensionNodeID(t *testing.T) {
 	Convey("Given HTTPClient.Do returns a 200 status", t, func() {
 		httpCliMock := &mocks.HTTPClientMock{}
 
-		importAPI := ImportAPI{
-			ImportHost: host,
-			HTTPClient: httpCliMock,
-			AuthToken:  authToken,
+		datasetAPI := DatasetAPI{
+			DatasetAPIHost:      host,
+			HTTPClient:          httpCliMock,
+			DatasetAPIAuthToken: authToken,
 		}
 		httpCliMock.DoFunc = func(req *http.Request) (*http.Response, error) {
 			return Response([]byte{}, 200, nil)
 		}
 
 		Convey("When PutDimensionNodeID is called", func() {
-			err := importAPI.PutDimensionNodeID(instanceID, dimensionOne)
+			err := datasetAPI.PutDimensionNodeID(instanceID, dimensionOne)
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldEqual, nil)

--- a/cmd/dp-dimension-importer/main.go
+++ b/cmd/dp-dimension-importer/main.go
@@ -58,17 +58,17 @@ func main() {
 		return repository.NewDimensionRepository(neo4jClient, map[string]string{})
 	}
 
-	importAPI := client.ImportAPI{
-		ResponseBodyReader: responseBodyReader{},
-		HTTPClient:         &http.Client{},
-		AuthToken:          cfg.ImportAuthToken,
-		ImportHost:         cfg.ImportAddr,
+	datasetAPI := client.DatasetAPI{
+		ResponseBodyReader:  responseBodyReader{},
+		HTTPClient:          &http.Client{},
+		DatasetAPIHost:      cfg.DatasetAPIAddr,
+		DatasetAPIAuthToken: cfg.DatasetAPIAuthToken,
 	}
 
 	eventHandler := &handler.DimensionsExtractedEventHandler{
 		NewDimensionInserter: newDimensionInserterFunc,
 		InstanceRepository:   &repository.InstanceRepository{Neo4j: neo4jClient},
-		ImportAPI:            importAPI,
+		DatasetAPI:           datasetAPI,
 	}
 
 	dimensionInsertedProducer := message.DimensionInsertedProducer{

--- a/config/importer.go
+++ b/config/importer.go
@@ -13,20 +13,20 @@ type Config struct {
 	KafkaAddr                []string `envconfig:"KAFKA_ADDR"`
 	DimensionsExtractedTopic string   `envconfig:"DIMENSIONS_EXTRACTED_TOPIC"`
 	DimensionsInsertedTopic  string   `envconfig:"DIMENSIONS_INSERTED_TOPIC"`
-	ImportAddr               string   `envconfig:"IMPORT_ADDR"`
-	ImportAuthToken          string   `envconfig:"IMPORT_AUTH_TOKEN"`
+	DatasetAPIAddr           string   `envconfig:"DATASET_API_ADDR"`
+	DatasetAPIAuthToken      string   `envconfig:"DATASET_API_AUTH_TOKEN"`
 	DatabaseURL              string   `envconfig:"DB_URL"`
 	PoolSize                 int      `envconfig:"DB_POOL_SIZE"`
 }
 
 func (c *Config) String() string {
 	authTokenFound := "NOT FOUND"
-	if len(c.ImportAuthToken) > 0 {
+	if len(c.DatasetAPIAuthToken) > 0 {
 		authTokenFound = "FOUND"
 	}
 
 	masked := Config(*c)
-	masked.ImportAuthToken = authTokenFound
+	masked.DatasetAPIAuthToken = authTokenFound
 
 	b, _ := json.Marshal(masked)
 	return string(b)
@@ -36,8 +36,8 @@ func (c *Config) String() string {
 func Load() (*Config, error) {
 	cfg := Config{
 		BindAddr:                 ":21000",
-		ImportAddr:               "http://localhost:21800",
-		ImportAuthToken:          "FD0108EA-825D-411C-9B1D-41EF7727F465",
+		DatasetAPIAddr:           "http://localhost:22000",
+		DatasetAPIAuthToken:      "FD0108EA-825D-411C-9B1D-41EF7727F465",
 		DatabaseURL:              "bolt://localhost:7687",
 		PoolSize:                 20,
 		KafkaAddr:                []string{"localhost:9092"},
@@ -47,8 +47,8 @@ func Load() (*Config, error) {
 
 	err := envconfig.Process("", &cfg)
 
-	if len(cfg.ImportAuthToken) == 0 {
-		err := errors.New("error while attempting to load config. import api auth token is required but has not been configured")
+	if len(cfg.DatasetAPIAuthToken) == 0 {
+		err := errors.New("error while attempting to load config. dataset api auth token is required but has not been configured")
 		log.Error(err, nil)
 		return nil, err
 	}

--- a/handler/dimensions_extracted.go
+++ b/handler/dimensions_extracted.go
@@ -9,15 +9,15 @@ import (
 	"time"
 )
 
-//go:generate moq -out ../mocks/dimensions_extracted_generated_mocks.go -pkg mocks . ImportAPIClient InstanceRepository DimensionRepository
+//go:generate moq -out ../mocks/dimensions_extracted_generated_mocks.go -pkg mocks . DatasetAPIClient InstanceRepository DimensionRepository
 
 const (
 	logEventRecieved        = "handling dimensions extracted event"
 	dimensionCliErrMsg      = "error when calling dimensions client"
-	instanceErrMsg          = "error when calling the import api to retrieve instance data"
-	updateNodeIDErr         = "unexpected error while calling import api set dimension node id endpoint"
+	instanceErrMsg          = "error when calling the dataset api to retrieve instance data"
+	updateNodeIDErr         = "unexpected error while calling dataset api set dimension node id endpoint"
 	createInstanceErr       = "unexpected error while attempting to create instance"
-	importAPINilErr         = "dimensions extracted event handler: import api expected but was nil"
+	datasetAPINilErr        = "dimensions extracted event handler: dataset api expected but was nil"
 	createDimRepoNilErr     = "dimensions extracted event handler: new dimension inserter expected but was nil"
 	instanceRepoNilErr      = "dimensions extracted event handler: instance repository expected but was nil"
 	instanceIDNilErr        = "dimensions extracted event: instance id is required but was nil"
@@ -26,8 +26,8 @@ const (
 	eventProcessingComplete = "event processing complete"
 )
 
-// ImportAPIClient defines interface of an Import API client,
-type ImportAPIClient interface {
+// DatasetAPIClient defines interface of an Dataset API client,
+type DatasetAPIClient interface {
 	GetDimensions(instanceID string) ([]*model.Dimension, error)
 	PutDimensionNodeID(instanceID string, dimension *model.Dimension) error
 	GetInstance(instanceID string) (*model.Instance, error)
@@ -48,15 +48,15 @@ type DimensionRepository interface {
 type DimensionsExtractedEventHandler struct {
 	NewDimensionInserter func() DimensionRepository
 	InstanceRepository   InstanceRepository
-	ImportAPI            ImportAPIClient
+	DatasetAPI           DatasetAPIClient
 }
 
-// HandleEvent retrieves the dimensions for specified instanceID from the Import API, creates an MyInstance entity for
+// HandleEvent retrieves the dimensions for specified instanceID from the Dataset API, creates an MyInstance entity for
 // provided instanceID, creates a Dimension entity for each dimension and a relationship to the MyInstance it belongs to
 // and makes a PUT request to the Import API with the database ID of each Dimension entity.
 func (hdlr *DimensionsExtractedEventHandler) HandleEvent(event event.DimensionsExtractedEvent) error {
-	if hdlr.ImportAPI == nil {
-		return errors.New(importAPINilErr)
+	if hdlr.DatasetAPI == nil {
+		return errors.New(datasetAPINilErr)
 	}
 	if hdlr.InstanceRepository == nil {
 		return errors.New(instanceRepoNilErr)
@@ -78,15 +78,15 @@ func (hdlr *DimensionsExtractedEventHandler) HandleEvent(event event.DimensionsE
 	var dimensions []*model.Dimension
 	var err error
 
-	if dimensions, err = hdlr.ImportAPI.GetDimensions(event.InstanceID); err != nil {
+	if dimensions, err = hdlr.DatasetAPI.GetDimensions(event.InstanceID); err != nil {
 		log.ErrorC(dimensionCliErrMsg, err, logData)
 		return errors.New(dimensionCliErrMsg)
 	}
 
 	logData[logKeys.DimensionsCount] = len(dimensions)
 
-	// retrieve the CSV header from the import API and attach it to the instance node allowing it to be used after import.
-	instance, err := hdlr.ImportAPI.GetInstance(event.InstanceID)
+	// retrieve the CSV header from the dataset API and attach it to the instance node allowing it to be used after import.
+	instance, err := hdlr.DatasetAPI.GetInstance(event.InstanceID)
 	if err != nil {
 		log.ErrorC(instanceErrMsg, err, logData)
 		return errors.New(instanceErrMsg)
@@ -106,7 +106,7 @@ func (hdlr *DimensionsExtractedEventHandler) HandleEvent(event event.DimensionsE
 			return err
 		}
 
-		if err = hdlr.ImportAPI.PutDimensionNodeID(event.InstanceID, dimension); err != nil {
+		if err = hdlr.DatasetAPI.PutDimensionNodeID(event.InstanceID, dimension); err != nil {
 			log.ErrorC(updateNodeIDErr, err, nil)
 			return errors.New(updateNodeIDErr)
 		}

--- a/handler/dimensions_extracted_test.go
+++ b/handler/dimensions_extracted_test.go
@@ -47,7 +47,7 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 			},
 		}
 
-		importAPIMock := &mocks.ImportAPIClientMock{
+		importAPIMock := &mocks.DatasetAPIClientMock{
 			GetDimensionsFunc: func(instanceID string) ([]*model.Dimension, error) {
 				return []*model.Dimension{d1, d2}, nil
 			},
@@ -64,19 +64,19 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 				return dimensionRepository
 			},
 			InstanceRepository: instanceRepositoryMock,
-			ImportAPI:          importAPIMock,
+			DatasetAPI:         importAPIMock,
 		}
 
 		Convey("When given a valid event", func() {
 			event := event.DimensionsExtractedEvent{InstanceID: testInstanceID}
 			handler.HandleEvent(event)
 
-			Convey("Then ImportAPI.GetDimensions is called 1 time with the expected parameters", func() {
+			Convey("Then DatasetAPI.GetDimensions is called 1 time with the expected parameters", func() {
 				So(len(importAPIMock.GetDimensionsCalls()), ShouldEqual, 1)
 				So(importAPIMock.GetDimensionsCalls()[0].InstanceID, ShouldEqual, testInstanceID)
 			})
 
-			Convey("Then ImportAPI.GetInstance is called 1 time", func() {
+			Convey("Then DatasetAPI.GetInstance is called 1 time", func() {
 				So(len(importAPIMock.GetInstanceCalls()), ShouldEqual, 1)
 			})
 
@@ -91,7 +91,7 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 				So(calls[1].Dimension, ShouldResemble, d2)
 			})
 
-			Convey("And ImportAPI.PutDimensionNodeID is called 2 times with the expected parameters", func() {
+			Convey("And DatasetAPI.PutDimensionNodeID is called 2 times with the expected parameters", func() {
 				calls := importAPIMock.PutDimensionNodeIDCalls()
 				So(len(calls), ShouldEqual, 2)
 
@@ -125,7 +125,7 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 			})
 		})
 
-		Convey("When ImportAPI.GetDimensions returns an error", func() {
+		Convey("When DatasetAPI.GetDimensions returns an error", func() {
 			getDimensionsErr := errors.New("Get Dimensions error")
 			event := event.DimensionsExtractedEvent{InstanceID: testInstanceID}
 
@@ -135,11 +135,11 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 
 			err := handler.HandleEvent(event)
 
-			Convey("Then the ImportAPI.GetDimensions is called 1 time", func() {
+			Convey("Then the DatasetAPI.GetDimensions is called 1 time", func() {
 				So(len(importAPIMock.GetDimensionsCalls()), ShouldEqual, 1)
 			})
 
-			Convey("Then ImportAPI.GetInstance is called 1 time", func() {
+			Convey("Then DatasetAPI.GetInstance is called 1 time", func() {
 				So(len(importAPIMock.GetInstanceCalls()), ShouldEqual, 0)
 			})
 
@@ -165,11 +165,11 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 
 			err := handler.HandleEvent(event)
 
-			Convey("Then the ImportAPI.GetDimensions is called 1 time", func() {
+			Convey("Then the DatasetAPI.GetDimensions is called 1 time", func() {
 				So(len(importAPIMock.GetDimensionsCalls()), ShouldEqual, 1)
 			})
 
-			Convey("Then ImportAPI.GetInstance is called 1 time", func() {
+			Convey("Then DatasetAPI.GetInstance is called 1 time", func() {
 				So(len(importAPIMock.GetInstanceCalls()), ShouldEqual, 1)
 			})
 
@@ -199,11 +199,11 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 			}
 			err := handler.HandleEvent(event)
 
-			Convey("Then the ImportAPI.GetDimensions is called 1 time", func() {
+			Convey("Then the DatasetAPI.GetDimensions is called 1 time", func() {
 				So(len(importAPIMock.GetDimensionsCalls()), ShouldEqual, 1)
 			})
 
-			Convey("Then ImportAPI.GetInstance is called 1 time", func() {
+			Convey("Then DatasetAPI.GetInstance is called 1 time", func() {
 				So(len(importAPIMock.GetInstanceCalls()), ShouldEqual, 1)
 			})
 
@@ -230,7 +230,7 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 			})
 		})
 
-		Convey("When ImportAPI.PutDimensionNodeID returns an error", func() {
+		Convey("When DatasetAPI.PutDimensionNodeID returns an error", func() {
 			expectedErr := errors.New("Put Node ID error")
 			event := event.DimensionsExtractedEvent{InstanceID: testInstanceID}
 
@@ -243,11 +243,11 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 
 			err := handler.HandleEvent(event)
 
-			Convey("Then the ImportAPI.GetDimensions is called 1 time", func() {
+			Convey("Then the DatasetAPI.GetDimensions is called 1 time", func() {
 				So(len(importAPIMock.GetDimensionsCalls()), ShouldEqual, 1)
 			})
 
-			Convey("Then ImportAPI.GetInstance is called 1 time", func() {
+			Convey("Then DatasetAPI.GetInstance is called 1 time", func() {
 				So(len(importAPIMock.GetInstanceCalls()), ShouldEqual, 1)
 			})
 
@@ -264,7 +264,7 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 				So(calls[0].Dimension, ShouldResemble, d1)
 			})
 
-			Convey("And ImportAPI.PutDimensionNodeID is called 1 time with the expected parameters", func() {
+			Convey("And DatasetAPI.PutDimensionNodeID is called 1 time with the expected parameters", func() {
 				calls := importAPIMock.PutDimensionNodeIDCalls()
 				So(len(calls), ShouldEqual, 1)
 
@@ -297,11 +297,11 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 
 			err := handler.HandleEvent(event)
 
-			Convey("Then the ImportAPI.GetDimensions is called 1 time", func() {
+			Convey("Then the DatasetAPI.GetDimensions is called 1 time", func() {
 				So(len(importAPIMock.GetDimensionsCalls()), ShouldEqual, 1)
 			})
 
-			Convey("Then ImportAPI.GetInstance is called 1 time", func() {
+			Convey("Then DatasetAPI.GetInstance is called 1 time", func() {
 				So(len(importAPIMock.GetInstanceCalls()), ShouldEqual, 1)
 			})
 
@@ -321,7 +321,7 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 				So(calls[1].Dimension, ShouldResemble, d2)
 			})
 
-			Convey("And ImportAPI.PutDimensionNodeID is called 1 time with the expected parameters", func() {
+			Convey("And DatasetAPI.PutDimensionNodeID is called 1 time with the expected parameters", func() {
 				calls := importAPIMock.PutDimensionNodeIDCalls()
 				So(len(calls), ShouldEqual, 2)
 
@@ -338,12 +338,12 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 		})
 	})
 
-	Convey("Given handler.ImportAPI has not been configured", t, func() {
+	Convey("Given handler.DatasetAPI has not been configured", t, func() {
 		instanceRepositoryMock := &mocks.InstanceRepositoryMock{}
 		dimensionRepository := &mocks.DimensionRepositoryMock{}
 
 		handler := DimensionsExtractedEventHandler{
-			ImportAPI:          nil,
+			DatasetAPI:         nil,
 			InstanceRepository: instanceRepositoryMock,
 			NewDimensionInserter: func() DimensionRepository {
 				return dimensionRepository
@@ -354,7 +354,7 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 			err := handler.HandleEvent(event)
 
 			Convey("Then the expected error is returned", func() {
-				So(err, ShouldResemble, errors.New(importAPINilErr))
+				So(err, ShouldResemble, errors.New(datasetAPINilErr))
 			})
 
 			Convey("And the event is not handled", func() {
@@ -367,10 +367,10 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 
 	Convey("Given handler.InstanceRepository has not been configured", t, func() {
 		dimensionRepository := &mocks.DimensionRepositoryMock{}
-		importAPIMock := &mocks.ImportAPIClientMock{}
+		importAPIMock := &mocks.DatasetAPIClientMock{}
 
 		handler := DimensionsExtractedEventHandler{
-			ImportAPI:          importAPIMock,
+			DatasetAPI:         importAPIMock,
 			InstanceRepository: nil,
 			NewDimensionInserter: func() DimensionRepository {
 				return dimensionRepository
@@ -392,11 +392,11 @@ func TestDimensionsExtractedEventHandler_HandleEvent(t *testing.T) {
 	})
 
 	Convey("Given handler.InstanceRepository has not been configured", t, func() {
-		importAPIMock := &mocks.ImportAPIClientMock{}
+		importAPIMock := &mocks.DatasetAPIClientMock{}
 		instanceRepositoryMock := &mocks.InstanceRepositoryMock{}
 
 		handler := DimensionsExtractedEventHandler{
-			ImportAPI:            importAPIMock,
+			DatasetAPI:           importAPIMock,
 			InstanceRepository:   instanceRepositoryMock,
 			NewDimensionInserter: nil,
 		}

--- a/message/consumer_test.go
+++ b/message/consumer_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/ONSdigital/dp-dimension-importer/message/message_test"
 	"github.com/ONSdigital/dp-dimension-importer/schema"
 	"github.com/ONSdigital/go-ns/kafka"
+	"github.com/ONSdigital/go-ns/log"
 	. "github.com/smartystreets/goconvey/convey"
 	"testing"
 	"time"
-	"github.com/ONSdigital/go-ns/log"
 )
 
 var (

--- a/mocks/dimensions_extracted_generated_mocks.go
+++ b/mocks/dimensions_extracted_generated_mocks.go
@@ -9,17 +9,17 @@ import (
 )
 
 var (
-	lockImportAPIClientMockGetDimensions      sync.RWMutex
-	lockImportAPIClientMockGetInstance        sync.RWMutex
-	lockImportAPIClientMockPutDimensionNodeID sync.RWMutex
+	lockDatasetAPIClientMockGetDimensions      sync.RWMutex
+	lockDatasetAPIClientMockGetInstance        sync.RWMutex
+	lockDatasetAPIClientMockPutDimensionNodeID sync.RWMutex
 )
 
-// ImportAPIClientMock is a mock implementation of ImportAPIClient.
+// DatasetAPIClientMock is a mock implementation of DatasetAPIClient.
 //
-//     func TestSomethingThatUsesImportAPIClient(t *testing.T) {
+//     func TestSomethingThatUsesDatasetAPIClient(t *testing.T) {
 //
-//         // make and configure a mocked ImportAPIClient
-//         mockedImportAPIClient := &ImportAPIClientMock{
+//         // make and configure a mocked DatasetAPIClient
+//         mockedDatasetAPIClient := &DatasetAPIClientMock{
 //             GetDimensionsFunc: func(instanceID string) ([]*model.Dimension, error) {
 // 	               panic("TODO: mock out the GetDimensions method")
 //             },
@@ -31,11 +31,11 @@ var (
 //             },
 //         }
 //
-//         // TODO: use mockedImportAPIClient in code that requires ImportAPIClient
+//         // TODO: use mockedDatasetAPIClient in code that requires DatasetAPIClient
 //         //       and then make assertions.
 //
 //     }
-type ImportAPIClientMock struct {
+type DatasetAPIClientMock struct {
 	// GetDimensionsFunc mocks the GetDimensions method.
 	GetDimensionsFunc func(instanceID string) ([]*model.Dimension, error)
 
@@ -68,71 +68,71 @@ type ImportAPIClientMock struct {
 }
 
 // GetDimensions calls GetDimensionsFunc.
-func (mock *ImportAPIClientMock) GetDimensions(instanceID string) ([]*model.Dimension, error) {
+func (mock *DatasetAPIClientMock) GetDimensions(instanceID string) ([]*model.Dimension, error) {
 	if mock.GetDimensionsFunc == nil {
-		panic("moq: ImportAPIClientMock.GetDimensionsFunc is nil but ImportAPIClient.GetDimensions was just called")
+		panic("moq: DatasetAPIClientMock.GetDimensionsFunc is nil but DatasetAPIClient.GetDimensions was just called")
 	}
 	callInfo := struct {
 		InstanceID string
 	}{
 		InstanceID: instanceID,
 	}
-	lockImportAPIClientMockGetDimensions.Lock()
+	lockDatasetAPIClientMockGetDimensions.Lock()
 	mock.calls.GetDimensions = append(mock.calls.GetDimensions, callInfo)
-	lockImportAPIClientMockGetDimensions.Unlock()
+	lockDatasetAPIClientMockGetDimensions.Unlock()
 	return mock.GetDimensionsFunc(instanceID)
 }
 
 // GetDimensionsCalls gets all the calls that were made to GetDimensions.
 // Check the length with:
-//     len(mockedImportAPIClient.GetDimensionsCalls())
-func (mock *ImportAPIClientMock) GetDimensionsCalls() []struct {
+//     len(mockedDatasetAPIClient.GetDimensionsCalls())
+func (mock *DatasetAPIClientMock) GetDimensionsCalls() []struct {
 	InstanceID string
 } {
 	var calls []struct {
 		InstanceID string
 	}
-	lockImportAPIClientMockGetDimensions.RLock()
+	lockDatasetAPIClientMockGetDimensions.RLock()
 	calls = mock.calls.GetDimensions
-	lockImportAPIClientMockGetDimensions.RUnlock()
+	lockDatasetAPIClientMockGetDimensions.RUnlock()
 	return calls
 }
 
 // GetInstance calls GetInstanceFunc.
-func (mock *ImportAPIClientMock) GetInstance(instanceID string) (*model.Instance, error) {
+func (mock *DatasetAPIClientMock) GetInstance(instanceID string) (*model.Instance, error) {
 	if mock.GetInstanceFunc == nil {
-		panic("moq: ImportAPIClientMock.GetInstanceFunc is nil but ImportAPIClient.GetInstance was just called")
+		panic("moq: DatasetAPIClientMock.GetInstanceFunc is nil but DatasetAPIClient.GetInstance was just called")
 	}
 	callInfo := struct {
 		InstanceID string
 	}{
 		InstanceID: instanceID,
 	}
-	lockImportAPIClientMockGetInstance.Lock()
+	lockDatasetAPIClientMockGetInstance.Lock()
 	mock.calls.GetInstance = append(mock.calls.GetInstance, callInfo)
-	lockImportAPIClientMockGetInstance.Unlock()
+	lockDatasetAPIClientMockGetInstance.Unlock()
 	return mock.GetInstanceFunc(instanceID)
 }
 
 // GetInstanceCalls gets all the calls that were made to GetInstance.
 // Check the length with:
-//     len(mockedImportAPIClient.GetInstanceCalls())
-func (mock *ImportAPIClientMock) GetInstanceCalls() []struct {
+//     len(mockedDatasetAPIClient.GetInstanceCalls())
+func (mock *DatasetAPIClientMock) GetInstanceCalls() []struct {
 	InstanceID string
 } {
 	var calls []struct {
 		InstanceID string
 	}
-	lockImportAPIClientMockGetInstance.RLock()
+	lockDatasetAPIClientMockGetInstance.RLock()
 	calls = mock.calls.GetInstance
-	lockImportAPIClientMockGetInstance.RUnlock()
+	lockDatasetAPIClientMockGetInstance.RUnlock()
 	return calls
 }
 
 // PutDimensionNodeID calls PutDimensionNodeIDFunc.
-func (mock *ImportAPIClientMock) PutDimensionNodeID(instanceID string, dimension *model.Dimension) error {
+func (mock *DatasetAPIClientMock) PutDimensionNodeID(instanceID string, dimension *model.Dimension) error {
 	if mock.PutDimensionNodeIDFunc == nil {
-		panic("moq: ImportAPIClientMock.PutDimensionNodeIDFunc is nil but ImportAPIClient.PutDimensionNodeID was just called")
+		panic("moq: DatasetAPIClientMock.PutDimensionNodeIDFunc is nil but DatasetAPIClient.PutDimensionNodeID was just called")
 	}
 	callInfo := struct {
 		InstanceID string
@@ -141,16 +141,16 @@ func (mock *ImportAPIClientMock) PutDimensionNodeID(instanceID string, dimension
 		InstanceID: instanceID,
 		Dimension:  dimension,
 	}
-	lockImportAPIClientMockPutDimensionNodeID.Lock()
+	lockDatasetAPIClientMockPutDimensionNodeID.Lock()
 	mock.calls.PutDimensionNodeID = append(mock.calls.PutDimensionNodeID, callInfo)
-	lockImportAPIClientMockPutDimensionNodeID.Unlock()
+	lockDatasetAPIClientMockPutDimensionNodeID.Unlock()
 	return mock.PutDimensionNodeIDFunc(instanceID, dimension)
 }
 
 // PutDimensionNodeIDCalls gets all the calls that were made to PutDimensionNodeID.
 // Check the length with:
-//     len(mockedImportAPIClient.PutDimensionNodeIDCalls())
-func (mock *ImportAPIClientMock) PutDimensionNodeIDCalls() []struct {
+//     len(mockedDatasetAPIClient.PutDimensionNodeIDCalls())
+func (mock *DatasetAPIClientMock) PutDimensionNodeIDCalls() []struct {
 	InstanceID string
 	Dimension  *model.Dimension
 } {
@@ -158,9 +158,9 @@ func (mock *ImportAPIClientMock) PutDimensionNodeIDCalls() []struct {
 		InstanceID string
 		Dimension  *model.Dimension
 	}
-	lockImportAPIClientMockPutDimensionNodeID.RLock()
+	lockDatasetAPIClientMockPutDimensionNodeID.RLock()
 	calls = mock.calls.PutDimensionNodeID
-	lockImportAPIClientMockPutDimensionNodeID.RUnlock()
+	lockDatasetAPIClientMockPutDimensionNodeID.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
What

Call the dataset API instead of the import API for the instance related endpoints.

Waiting on the dataset API changes to be complete before integration testing the import services against it.

How to review

Review code changes

Who can review