### PR TITLE
Refactor to align model with updated dataset API

### DIFF
--- a/client/dimensions_api.go
+++ b/client/dimensions_api.go
@@ -163,8 +163,8 @@ func (api DatasetAPI) GetDimensions(instanceID string) ([]*model.Dimension, erro
 		return nil, err
 	}
 
-	var dims []*model.Dimension
-	err = json.Unmarshal(body, &dims)
+	var dimensionsResult model.DimensionNodeResults
+	err = json.Unmarshal(body, &dimensionsResult)
 
 	if err != nil {
 		data[logKeys.ErrorDetails] = err.Error()
@@ -173,7 +173,7 @@ func (api DatasetAPI) GetDimensions(instanceID string) ([]*model.Dimension, erro
 	}
 
 	log.Debug(getDimensionsSuccess, data)
-	return dims, nil
+	return dimensionsResult.Items, nil
 }
 
 // PutDimensionNodeID make a HTTP put request to update the node_id of the specified dimension.

--- a/client/dimensions_api_test.go
+++ b/client/dimensions_api_test.go
@@ -23,7 +23,10 @@ const (
 var expectedErr = errors.New("BOOM!")
 var dimensionOne = &model.Dimension{DimensionID: "666_SEX_MALE", NodeID: "1111", Value: "Male"}
 var dimensionTwo = &model.Dimension{DimensionID: "666_SEX_FEMALE", NodeID: "1112", Value: "Female"}
-var expectedDimensions = []*model.Dimension{dimensionOne, dimensionTwo}
+
+var expectedDimensions = model.DimensionNodeResults{
+	Items: []*model.Dimension{dimensionOne, dimensionTwo},
+}
 
 var expectedInstance = &model.Instance{InstanceID: instanceID, CSVHeader: []string{"the", "csv", "header"}}
 
@@ -351,7 +354,7 @@ func TestGetDimensions(t *testing.T) {
 			dims, err := datasetAPI.GetDimensions(instanceID)
 
 			Convey("Then the expected response is returned with no error", func() {
-				So(dims, ShouldResemble, expectedDimensions)
+				So(dims, ShouldResemble, expectedDimensions.Items)
 				So(err, ShouldEqual, nil)
 			})
 

--- a/model/models.go
+++ b/model/models.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 )
 
-const instanceLabelFmt = "_%s_Instance"
+// DimensionNodeResults wraps dimension node objects for pagination
+type DimensionNodeResults struct {
+	Items []*Dimension `json:"items"`
+}
 
 // Dimension struct encapsulating Dimension details.
 type Dimension struct {
@@ -24,7 +27,7 @@ func (d *Dimension) GetName(instanceID string) string {
 
 // Instance struct to hold instance information.
 type Instance struct {
-	InstanceID string   `json:"instance_id,omitempty"`
+	InstanceID string   `json:"id,omitempty"`
 	CSVHeader  []string `json:"headers"`
 	Dimensions []interface{}
 }


### PR DESCRIPTION
### What

Refactored model to use updated dataset model.

The dimension importer calls the dataset API to get the list of dimensions to import. The updated dataset API model returns an object containing a list of dimensions instead of just the array.

### How to review

Review code changes + check that this service can retrieve the list of dimensions from the dataset API.

### Who can review

Anyone
