### PR TITLE
Use updated kafka lib with indefinite offset retention.

### DIFF
--- a/cmd/dp-dimension-importer/main.go
+++ b/cmd/dp-dimension-importer/main.go
@@ -144,7 +144,7 @@ func main() {
 }
 
 func newConsumer(kafkaAddr []string, topic string, namespace string) *kafka.ConsumerGroup {
-	consumer, err := kafka.NewSyncConsumer(kafkaAddr, topic, namespace, kafka.OffsetOldest)
+	consumer, err := kafka.NewSyncConsumer(kafkaAddr, topic, namespace, kafka.OffsetNewest)
 	if err != nil {
 		log.ErrorC("kafka.NewSyncConsumer returned an error", err, log.Data{
 			"brokers":        kafkaAddr,

--- a/vendor/github.com/ONSdigital/go-ns/kafka/consumer-group.go
+++ b/vendor/github.com/ONSdigital/go-ns/kafka/consumer-group.go
@@ -117,8 +117,9 @@ func newConsumer(brokers []string, topic string, group string, offset int64, syn
 	config.Consumer.Return.Errors = true
 	config.Consumer.MaxWaitTime = 50 * time.Millisecond
 	config.Consumer.Offsets.Initial = offset
+	config.Consumer.Offsets.Retention = 0 // indefinite retention
 
-	logData := log.Data{"topic": topic, "group": group}
+	logData := log.Data{"topic": topic, "group": group, "config": config}
 
 	consumer, err := cluster.NewConsumer(brokers, group, []string{topic}, config)
 	if err != nil {
@@ -149,7 +150,7 @@ func newConsumer(brokers []string, topic string, group string, offset int64, syn
 	// listener goroutine - listen to consumer.Messages() and upstream them
 	// if this blocks while upstreaming a message, we can shutdown consumer via the following goroutine
 	go func() {
-		logData := log.Data{"topic": topic, "group": group}
+		logData := log.Data{"topic": topic, "group": group, "config": config}
 
 		log.Info("Started kafka consumer listener", logData)
 		defer close(cg.closed)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,10 +39,10 @@
 			"revisionTime": "2017-11-27T12:13:36Z"
 		},
 		{
-			"checksumSHA1": "d0xkjPw9SKVWK1vDJqvD3HoFbnA=",
+			"checksumSHA1": "qqaN4hllMTNueffB5bcz8xQnwX0=",
 			"path": "github.com/ONSdigital/go-ns/kafka",
-			"revision": "84ec91434eab3ba06a753895619f60ee0ccf6552",
-			"revisionTime": "2017-11-27T12:13:36Z"
+			"revision": "b7a9d79bc028131d34399e7ef420b73007786202",
+			"revisionTime": "2018-01-23T16:28:19Z"
 		},
 		{
 			"checksumSHA1": "AjbjbhFVAOP/1NU5HL+uy+X/yJo=",


### PR DESCRIPTION
Pessimistically use kafka.OffsetNewest as the initial offset until we
are confident that the issue is entirely fixed. The worst case scenario
using OffsetNewest is lost messages. For the import process this means
trying the import again. The worst case when using OffsetOldest is
replaying messages and making data inconsistent. We should consider
changing all services to use kafka.OffsetOldest when the issue is fixed,
so that no messages are lost when the service first starts.

### What

Describe what you have changed and why.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
