### PR TITLE
Updated default healthcheck config and upgraded to latest dp-healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Scripts for updating and debugging Kafka can be found [here](https://github.com/
 | DIMENSIONS_INSERTED_TOPIC           | dimensions-inserted                  | The topic to write output messages when dimensions are inserted
 | EVENT_REPORTER_TOPIC                | report-events                        | The topic to write output messages when any errors occur during processing an instance
 | GRACEFUL_SHUTDOWN_TIMEOUT           | 5s                                   | The graceful shutdown timeout (time.Duration)
-| HEALTHCHECK_INTERVAL                | 60s                                  | How often to run a health check (time.Duration)
+| HEALTHCHECK_INTERVAL                | 30s                                  | The period of time between health checks (time.Duration)
+| HEALTHCHECK_CRITICAL_TIMEOUT        | 90s                                  | The period of time after which failing checks will result in critical global check (time.Duration)
 | SERVICE_AUTH_TOKEN                  | 4424A9F2-B903-40F4-85F1-240107D1AFAF | The service authorization token
 | ZEBEDEE_URL                         | http://localhost:8082                | The host name for Zebedee
 

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	DatasetAPIAddr                 string        `envconfig:"DATASET_API_ADDR"`
 	GracefulShutdownTimeout        time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval            time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
-	HealthCheckRecoveryInterval    time.Duration `envconfig:"HEALTHCHECK_RECOVERY_INTERVAL"`
+	HealthCheckCriticalTimeout     time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 }
 
 var cfg *Config
@@ -43,8 +43,8 @@ func Get(ctx context.Context) (*Config, error) {
 		OutgoingInstancesTopic:         "dimensions-inserted",
 		EventReporterTopic:             "report-events",
 		GracefulShutdownTimeout:        time.Second * 5,
-		HealthCheckInterval:            10 * time.Second,
-		HealthCheckRecoveryInterval:    1 * time.Minute,
+		HealthCheckInterval:            30 * time.Second,
+		HealthCheckCriticalTimeout:     90 * time.Second,
 	}
 
 	if len(cfg.ServiceAuthToken) == 0 {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.9.0
 	github.com/ONSdigital/dp-graph/v2 v2.0.1
-	github.com/ONSdigital/dp-healthcheck v1.0.2
+	github.com/ONSdigital/dp-healthcheck v1.0.3
 	github.com/ONSdigital/dp-kafka v1.1.5
 	github.com/ONSdigital/dp-reporter-client v1.0.0
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h
 github.com/ONSdigital/dp-healthcheck v1.0.0 h1:bySQU8kQRs4n3WbgH8QtVwCJLqG9ri722saATjvNNfc=
 github.com/ONSdigital/dp-healthcheck v1.0.0/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.1/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
-github.com/ONSdigital/dp-healthcheck v1.0.2 h1:N8SzpYzdixVgJS9NMzTBA2RZ2bi3Am1wE5F8ROEpTYw=
-github.com/ONSdigital/dp-healthcheck v1.0.2/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
+github.com/ONSdigital/dp-healthcheck v1.0.3 h1:wNA34U3uPD5t1SE8P3cbGqNZP4CUjyJFbSugPYgrBG0=
+github.com/ONSdigital/dp-healthcheck v1.0.3/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-kafka v1.1.1/go.mod h1:5wrPA3e92d82nOIhdzTsKW5hecJ14LO5URWGUEvPkQU=
 github.com/ONSdigital/dp-kafka v1.1.5 h1:viB+ajyTx0RNEUMz5Qoi5h6xAHSWwsJWWwokk3WN+1k=
 github.com/ONSdigital/dp-kafka v1.1.5/go.mod h1:s/8OV37Sx35wgNXw3VYlpRxJfldJLnXWPepY+SI45w8=

--- a/initialise/initialise.go
+++ b/initialise/initialise.go
@@ -104,7 +104,7 @@ func (e *ExternalServiceList) GetHealthChecker(ctx context.Context, buildTime, g
 		log.Event(ctx, "failed to create versionInfo for healthcheck", log.FATAL, log.Error(err))
 		return nil, err
 	}
-	hc := healthcheck.New(versionInfo, cfg.HealthCheckRecoveryInterval, cfg.HealthCheckInterval)
+	hc := healthcheck.New(versionInfo, cfg.HealthCheckCriticalTimeout, cfg.HealthCheckInterval)
 	e.HealthCheck = true
 
 	return &hc, nil


### PR DESCRIPTION
### What

Updated default healthcheck config values:
- HealthCheckInterval:        30 * time.Second (env `HEALTHCHECK_INTERVAL`)
- HealthCheckCriticalTimeout: 90 * time.Second (env `HEALTHCHECK_CRITICAL_TIMEOUT`)

### How to review

- Make sure the default config uses the expected values and env vars

### Who can review

Anyone.