### PR TITLE
Fix panic caused by double message commit.

### DIFF
--- a/message/consumer.go
+++ b/message/consumer.go
@@ -58,7 +58,6 @@ func (c Consumer) Listen() {
 			case consumedMessage := <-c.consumer.Channels().Upstream:
 				log.Event(c.ctx, "consumer received a message", log.INFO, logData)
 				c.messageReceiver.OnMessage(consumedMessage)
-				consumedMessage.Commit()
 			case <-c.ctx.Done():
 				log.Event(c.ctx, "loggercontext done received event, attempting to close consumer", log.INFO, logData)
 				return

--- a/message/consumer_test.go
+++ b/message/consumer_test.go
@@ -68,9 +68,7 @@ func TestConsumer_Listen(t *testing.T) {
 
 			Convey("Then messageReceiver.OnMessage is called 1 time with the expected parameters", func() {
 				So(len(handleCalls), ShouldEqual, 1)
-				So(len(msg.CommitCalls()), ShouldEqual, 1)
 			})
 		})
-
 	})
 }


### PR DESCRIPTION
### What
- Fix panic caused by double message commit. The Kafka message was being committed twice, which caused a panic causing the service to die. 

### How to review
Check changes / tests

### Who can review
Anyone
