### PR TITLE
Updated to dp-kafka v2.1.0, which reintroduced CommitAndRelease (msg lvl)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go v1.30.0
 	github.com/ONSdigital/dp-graph/v2 v2.2.2
 	github.com/ONSdigital/dp-healthcheck v1.0.5
-	github.com/ONSdigital/dp-kafka/v2 v2.0.2
+	github.com/ONSdigital/dp-kafka/v2 v2.1.0
 	github.com/ONSdigital/dp-net v1.0.9
 	github.com/ONSdigital/dp-reporter-client v1.0.1
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAj
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-kafka/v2 v2.0.2 h1:GD8uF18bc7ub2vjvFm+5mfwtb4wRJiPunw1iTzAIttA=
 github.com/ONSdigital/dp-kafka/v2 v2.0.2/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
+github.com/ONSdigital/dp-kafka/v2 v2.1.0 h1:xYWdTqyS7q7ps5KzmrKAgPvU9//EnioI8nsNv9RU7og=
+github.com/ONSdigital/dp-kafka/v2 v2.1.0/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=

--- a/message/kafka_message_receiver.go
+++ b/message/kafka_message_receiver.go
@@ -46,5 +46,5 @@ func (r KafkaMessageReceiver) OnMessage(message kafka.Message) {
 	}
 
 	log.Event(ctx, "new instance event successfully processed", log.INFO, logData)
-	message.Commit()
+	message.CommitAndRelease()
 }

--- a/message/kafka_message_receiver_test.go
+++ b/message/kafka_message_receiver_test.go
@@ -46,8 +46,10 @@ func TestKafkaMessageHandler_Handle(t *testing.T) {
 			So(len(fixture.errorReporter.NotifyCalls()), ShouldEqual, 0)
 		})
 
-		Convey("And message.Commit is called 1 time", func() {
-			So(len(fixture.message.CommitCalls()), ShouldEqual, 1)
+		Convey("And message.CommitAndRelease is called 1 time", func() {
+			So(fixture.message.IsMarked(), ShouldBeTrue)
+			So(fixture.message.IsCommitted(), ShouldBeTrue)
+			So(len(fixture.message.CommitAndReleaseCalls()), ShouldEqual, 1)
 		})
 	})
 }
@@ -76,8 +78,10 @@ func TestKafkaMessageHandler_Handle_InvalidKafkaMessage(t *testing.T) {
 				So(len(fix.instanceHdlrCalls), ShouldEqual, 0)
 			})
 
-			Convey("And message.Commit is never called", func() {
-				So(len(fix.message.CommitCalls()), ShouldEqual, 0)
+			Convey("And message.CommitAndRelease is never called", func() {
+				So(fix.message.IsMarked(), ShouldBeFalse)
+				So(fix.message.IsCommitted(), ShouldBeFalse)
+				So(len(fix.message.CommitAndReleaseCalls()), ShouldEqual, 0)
 			})
 		})
 
@@ -118,8 +122,10 @@ func TestKafkaMessageHandler_Handle_InstanceHandlerError(t *testing.T) {
 			So(fix.errorReporter.NotifyCalls()[0].ErrContext, ShouldEqual, "InstanceHandler.Handle returned an unexpected error")
 		})
 
-		Convey("And message.Commit is never called", func() {
-			So(len(fix.message.CommitCalls()), ShouldEqual, 0)
+		Convey("And message.CommitAndRelease is never called", func() {
+			So(fix.message.IsMarked(), ShouldBeFalse)
+			So(fix.message.IsCommitted(), ShouldBeFalse)
+			So(len(fix.message.CommitAndReleaseCalls()), ShouldEqual, 0)
 		})
 	})
 }


### PR DESCRIPTION
### What

- Updated to dp-kafka 2.1.0, which reintroduces CommitAndRelease (at message level)
- Updated accordingly (msg.Commit() -> msg.CommitAndRelease())

### How to review

- Make sure code changes make sense (`CommitAndRelease` implements the same logic that `Commit` did in the dp-kafka v2.0.x)
- Make sure unit tests pass

### Who can review

Anyone
