### PR TITLE
Upgrade to dp-graph v2.5.0

### DIFF
--- a/cmd/dp-dimension-importer/main.go
+++ b/cmd/dp-dimension-importer/main.go
@@ -76,7 +76,7 @@ func main() {
 
 	var graphErrorConsumer *graph.ErrorConsumer
 	if serviceList.GraphDB {
-		graphErrorConsumer = graph.NewLoggingErrorConsumer(ctx, graphDB.Errors)
+		graphErrorConsumer = graph.NewLoggingErrorConsumer(ctx, graphDB.ErrorChan())
 	}
 
 	// MessageProducer for instanceComplete events.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.30.0
-	github.com/ONSdigital/dp-graph/v2 v2.2.2
+	github.com/ONSdigital/dp-graph/v2 v2.5.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.0.2
 	github.com/ONSdigital/dp-net v1.0.9

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.30.0 h1:TA3LHTccG4GHlUqDHGSrJRZEq15Wd1q1thE4Yxdv8H8=
 github.com/ONSdigital/dp-api-clients-go v1.30.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
-github.com/ONSdigital/dp-graph/v2 v2.2.2 h1:hqA+BCHdxsDw3KawdiemRmtWBQhAxDHP+DXhhFpk3H8=
-github.com/ONSdigital/dp-graph/v2 v2.2.2/go.mod h1:K4LIhFcyxB8g7nUG5I5I8x6QVf89x82dCEFBbE0mmaQ=
+github.com/ONSdigital/dp-graph/v2 v2.5.0 h1:4hQLXdZyiXBaFDTofsICfVuXqm1Sxkh8DIt9dGksh/c=
+github.com/ONSdigital/dp-graph/v2 v2.5.0/go.mod h1:wpBSdQi6KrY5lK76APeRR3Na/cqIpJMEZloc+/KOP/k=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
@@ -30,6 +30,8 @@ github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531
 github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531d/go.mod h1:75Sxr59AMz2RiPskqSymLFxdeaIEhnkNaJE5lonMS3M=
 github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d h1:yrCtEGlohmA3OnXtke0nOOp/m9O83orpSnTGOfYOw1Q=
 github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d/go.mod h1:zQ+8pTnCLGuy4eUek81pWUxZo4/f71ri3VYz97Wby+4=
+github.com/ONSdigital/graphson v0.1.0 h1:Z+9l9RGnSG5OU5sx/QanLEfhrHGqY+hni+7NJ2TLFAY=
+github.com/ONSdigital/graphson v0.1.0/go.mod h1:IRS8d1ydh1oczDKbLhTcqc/BNfgZyzhrrjr21SQOkjA=
 github.com/ONSdigital/gremgo-neptune v1.0.0 h1:l0Pizt2goXK5oCFeqs2sOkosZbF4sva0RpcR150VvNE=
 github.com/ONSdigital/gremgo-neptune v1.0.0/go.mod h1:GZz/N6xjNY+EN0x4FmfBDrM73R+Pr3aI5iCwYbY1oYQ=
 github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20/go.mod h1:BD7D8FWP1fzwUWsrCopEG72jl9cchCaVNIGSz6YvL+Y=

--- a/initialise/initialise.go
+++ b/initialise/initialise.go
@@ -3,6 +3,7 @@ package initialise
 import (
 	"context"
 	"fmt"
+	"github.com/ONSdigital/dp-dimension-importer/store"
 	"time"
 
 	"github.com/ONSdigital/dp-dimension-importer/config"
@@ -89,7 +90,7 @@ func (e *ExternalServiceList) GetProducer(ctx context.Context, topic string, nam
 }
 
 // GetGraphDB returns a connection to the graph DB
-func (e *ExternalServiceList) GetGraphDB(ctx context.Context) (*graph.DB, error) {
+func (e *ExternalServiceList) GetGraphDB(ctx context.Context) (store.Storer, error) {
 	graphDB, err := graph.New(ctx, graph.Subsets{Instance: true, Dimension: true})
 	if err != nil {
 		log.Event(ctx, "new graph db returned an error", log.FATAL, log.Error(err))

--- a/store/store.go
+++ b/store/store.go
@@ -16,10 +16,8 @@ type Storer interface {
 	AddDimensions(ctx context.Context, instanceID string, dimensions []interface{}) error
 	CreateCodeRelationship(ctx context.Context, instanceID, codeListID, code string) error
 	InstanceExists(ctx context.Context, instanceID string) (bool, error)
-	CountInsertedObservations(ctx context.Context, instanceID string) (count int64, err error)
-	AddVersionDetailsToInstance(ctx context.Context, instanceID, datasetID, edition string, version int) error
-	SetInstanceIsPublished(ctx context.Context, instanceID string) error
 	InsertDimension(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error)
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
 	Close(ctx context.Context) error
+	ErrorChan() chan error
 }

--- a/store/storertest/storer.go
+++ b/store/storertest/storer.go
@@ -33,9 +33,6 @@ var _ store.Storer = &StorerMock{}
 //             CloseFunc: func(ctx context.Context) error {
 // 	               panic("mock out the Close method")
 //             },
-//             CountInsertedObservationsFunc: func(ctx context.Context, instanceID string) (int64, error) {
-// 	               panic("mock out the CountInsertedObservations method")
-//             },
 //             CreateCodeRelationshipFunc: func(ctx context.Context, instanceID string, codeListID string, code string) error {
 // 	               panic("mock out the CreateCodeRelationship method")
 //             },
@@ -45,14 +42,14 @@ var _ store.Storer = &StorerMock{}
 //             CreateInstanceConstraintFunc: func(ctx context.Context, instanceID string) error {
 // 	               panic("mock out the CreateInstanceConstraint method")
 //             },
+//             ErrorChanFunc: func() chan error {
+// 	               panic("mock out the ErrorChan method")
+//             },
 //             InsertDimensionFunc: func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
 // 	               panic("mock out the InsertDimension method")
 //             },
 //             InstanceExistsFunc: func(ctx context.Context, instanceID string) (bool, error) {
 // 	               panic("mock out the InstanceExists method")
-//             },
-//             SetInstanceIsPublishedFunc: func(ctx context.Context, instanceID string) error {
-// 	               panic("mock out the SetInstanceIsPublished method")
 //             },
 //         }
 //
@@ -73,9 +70,6 @@ type StorerMock struct {
 	// CloseFunc mocks the Close method.
 	CloseFunc func(ctx context.Context) error
 
-	// CountInsertedObservationsFunc mocks the CountInsertedObservations method.
-	CountInsertedObservationsFunc func(ctx context.Context, instanceID string) (int64, error)
-
 	// CreateCodeRelationshipFunc mocks the CreateCodeRelationship method.
 	CreateCodeRelationshipFunc func(ctx context.Context, instanceID string, codeListID string, code string) error
 
@@ -85,14 +79,14 @@ type StorerMock struct {
 	// CreateInstanceConstraintFunc mocks the CreateInstanceConstraint method.
 	CreateInstanceConstraintFunc func(ctx context.Context, instanceID string) error
 
+	// ErrorChanFunc mocks the ErrorChan method.
+	ErrorChanFunc func() chan error
+
 	// InsertDimensionFunc mocks the InsertDimension method.
 	InsertDimensionFunc func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error)
 
 	// InstanceExistsFunc mocks the InstanceExists method.
 	InstanceExistsFunc func(ctx context.Context, instanceID string) (bool, error)
-
-	// SetInstanceIsPublishedFunc mocks the SetInstanceIsPublished method.
-	SetInstanceIsPublishedFunc func(ctx context.Context, instanceID string) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -130,13 +124,6 @@ type StorerMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
-		// CountInsertedObservations holds details about calls to the CountInsertedObservations method.
-		CountInsertedObservations []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// InstanceID is the instanceID argument value.
-			InstanceID string
-		}
 		// CreateCodeRelationship holds details about calls to the CreateCodeRelationship method.
 		CreateCodeRelationship []struct {
 			// Ctx is the ctx argument value.
@@ -164,6 +151,9 @@ type StorerMock struct {
 			// InstanceID is the instanceID argument value.
 			InstanceID string
 		}
+		// ErrorChan holds details about calls to the ErrorChan method.
+		ErrorChan []struct {
+		}
 		// InsertDimension holds details about calls to the InsertDimension method.
 		InsertDimension []struct {
 			// Ctx is the ctx argument value.
@@ -182,25 +172,17 @@ type StorerMock struct {
 			// InstanceID is the instanceID argument value.
 			InstanceID string
 		}
-		// SetInstanceIsPublished holds details about calls to the SetInstanceIsPublished method.
-		SetInstanceIsPublished []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// InstanceID is the instanceID argument value.
-			InstanceID string
-		}
 	}
 	lockAddDimensions               sync.RWMutex
 	lockAddVersionDetailsToInstance sync.RWMutex
 	lockChecker                     sync.RWMutex
 	lockClose                       sync.RWMutex
-	lockCountInsertedObservations   sync.RWMutex
 	lockCreateCodeRelationship      sync.RWMutex
 	lockCreateInstance              sync.RWMutex
 	lockCreateInstanceConstraint    sync.RWMutex
+	lockErrorChan                   sync.RWMutex
 	lockInsertDimension             sync.RWMutex
 	lockInstanceExists              sync.RWMutex
-	lockSetInstanceIsPublished      sync.RWMutex
 }
 
 // AddDimensions calls AddDimensionsFunc.
@@ -355,41 +337,6 @@ func (mock *StorerMock) CloseCalls() []struct {
 	return calls
 }
 
-// CountInsertedObservations calls CountInsertedObservationsFunc.
-func (mock *StorerMock) CountInsertedObservations(ctx context.Context, instanceID string) (int64, error) {
-	if mock.CountInsertedObservationsFunc == nil {
-		panic("StorerMock.CountInsertedObservationsFunc: method is nil but Storer.CountInsertedObservations was just called")
-	}
-	callInfo := struct {
-		Ctx        context.Context
-		InstanceID string
-	}{
-		Ctx:        ctx,
-		InstanceID: instanceID,
-	}
-	mock.lockCountInsertedObservations.Lock()
-	mock.calls.CountInsertedObservations = append(mock.calls.CountInsertedObservations, callInfo)
-	mock.lockCountInsertedObservations.Unlock()
-	return mock.CountInsertedObservationsFunc(ctx, instanceID)
-}
-
-// CountInsertedObservationsCalls gets all the calls that were made to CountInsertedObservations.
-// Check the length with:
-//     len(mockedStorer.CountInsertedObservationsCalls())
-func (mock *StorerMock) CountInsertedObservationsCalls() []struct {
-	Ctx        context.Context
-	InstanceID string
-} {
-	var calls []struct {
-		Ctx        context.Context
-		InstanceID string
-	}
-	mock.lockCountInsertedObservations.RLock()
-	calls = mock.calls.CountInsertedObservations
-	mock.lockCountInsertedObservations.RUnlock()
-	return calls
-}
-
 // CreateCodeRelationship calls CreateCodeRelationshipFunc.
 func (mock *StorerMock) CreateCodeRelationship(ctx context.Context, instanceID string, codeListID string, code string) error {
 	if mock.CreateCodeRelationshipFunc == nil {
@@ -507,6 +454,32 @@ func (mock *StorerMock) CreateInstanceConstraintCalls() []struct {
 	return calls
 }
 
+// ErrorChan calls ErrorChanFunc.
+func (mock *StorerMock) ErrorChan() chan error {
+	if mock.ErrorChanFunc == nil {
+		panic("StorerMock.ErrorChanFunc: method is nil but Storer.ErrorChan was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockErrorChan.Lock()
+	mock.calls.ErrorChan = append(mock.calls.ErrorChan, callInfo)
+	mock.lockErrorChan.Unlock()
+	return mock.ErrorChanFunc()
+}
+
+// ErrorChanCalls gets all the calls that were made to ErrorChan.
+// Check the length with:
+//     len(mockedStorer.ErrorChanCalls())
+func (mock *StorerMock) ErrorChanCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockErrorChan.RLock()
+	calls = mock.calls.ErrorChan
+	mock.lockErrorChan.RUnlock()
+	return calls
+}
+
 // InsertDimension calls InsertDimensionFunc.
 func (mock *StorerMock) InsertDimension(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
 	if mock.InsertDimensionFunc == nil {
@@ -582,40 +555,5 @@ func (mock *StorerMock) InstanceExistsCalls() []struct {
 	mock.lockInstanceExists.RLock()
 	calls = mock.calls.InstanceExists
 	mock.lockInstanceExists.RUnlock()
-	return calls
-}
-
-// SetInstanceIsPublished calls SetInstanceIsPublishedFunc.
-func (mock *StorerMock) SetInstanceIsPublished(ctx context.Context, instanceID string) error {
-	if mock.SetInstanceIsPublishedFunc == nil {
-		panic("StorerMock.SetInstanceIsPublishedFunc: method is nil but Storer.SetInstanceIsPublished was just called")
-	}
-	callInfo := struct {
-		Ctx        context.Context
-		InstanceID string
-	}{
-		Ctx:        ctx,
-		InstanceID: instanceID,
-	}
-	mock.lockSetInstanceIsPublished.Lock()
-	mock.calls.SetInstanceIsPublished = append(mock.calls.SetInstanceIsPublished, callInfo)
-	mock.lockSetInstanceIsPublished.Unlock()
-	return mock.SetInstanceIsPublishedFunc(ctx, instanceID)
-}
-
-// SetInstanceIsPublishedCalls gets all the calls that were made to SetInstanceIsPublished.
-// Check the length with:
-//     len(mockedStorer.SetInstanceIsPublishedCalls())
-func (mock *StorerMock) SetInstanceIsPublishedCalls() []struct {
-	Ctx        context.Context
-	InstanceID string
-} {
-	var calls []struct {
-		Ctx        context.Context
-		InstanceID string
-	}
-	mock.lockSetInstanceIsPublished.RLock()
-	calls = mock.calls.SetInstanceIsPublished
-	mock.lockSetInstanceIsPublished.RUnlock()
 	return calls
 }


### PR DESCRIPTION
### What
Upgrade to dp-graph v2.5.0
- Add ErrorChan() to storer interface, and use the interface in place of the concrete type
- Remove unused interface methods
- Regenerate storer mock

### How to review
Check changes / tests

### Who can review
Anyone
