### PR TITLE
use code to get order, instead of label

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.34.2
-	github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210317122038-a3e2f1c282a2
+	github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210317134336-6842b583aef5
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2
 	github.com/ONSdigital/dp-net v1.0.12

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.34.2
-	github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210318094659-fdf21a061938
+	github.com/ONSdigital/dp-graph/v2 v2.9.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2
 	github.com/ONSdigital/dp-net v1.0.12
@@ -12,7 +12,6 @@ require (
 	github.com/ONSdigital/go-ns v0.0.0-20200902154605-290c8b5ba5eb
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/gorilla/mux v1.8.0
-	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.34.2
-	github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210316112733-2e074664dc6b
+	github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210317122038-a3e2f1c282a2
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2
 	github.com/ONSdigital/dp-net v1.0.12

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.34.2
-	github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210317134336-6842b583aef5
+	github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210318094659-fdf21a061938
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2
 	github.com/ONSdigital/dp-net v1.0.12

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.34.2
-	github.com/ONSdigital/dp-graph/v2 v2.7.4-0.20210312123934-fccf43d50e72
+	github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210316112733-2e074664dc6b
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2
 	github.com/ONSdigital/dp-net v1.0.12

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.34.2 h1:4oVv0YbpxZn4V1H/X7RFQqlAPdXBlthKTarvrDq+tbU=
 github.com/ONSdigital/dp-api-clients-go v1.34.2/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
-github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210318094659-fdf21a061938 h1:KV4EGVyuZmgLXwXjCs20X8YjUNuBuKTgah6uLnFAHR8=
-github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210318094659-fdf21a061938/go.mod h1:HqPhOmhl65ApBfbILV+mgMtAh0/45BowpZWKVzxe8tM=
+github.com/ONSdigital/dp-graph/v2 v2.9.0 h1:S3zNRfzjApPRV23EC/EhclaLZ02u5V/RVSdO3q3rdgA=
+github.com/ONSdigital/dp-graph/v2 v2.9.0/go.mod h1:bhiKBX0l62HWaYMN4d6vjldayPTGB3fd7W4kVqNsiwU=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
@@ -32,8 +32,8 @@ github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531
 github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531d/go.mod h1:75Sxr59AMz2RiPskqSymLFxdeaIEhnkNaJE5lonMS3M=
 github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d h1:yrCtEGlohmA3OnXtke0nOOp/m9O83orpSnTGOfYOw1Q=
 github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d/go.mod h1:zQ+8pTnCLGuy4eUek81pWUxZo4/f71ri3VYz97Wby+4=
-github.com/ONSdigital/graphson v0.1.1-0.20210317162900-dbbc920ad87a h1:K1Wu0HnkacG4HieNqEkLg8z7Nv2zz0PCbXDVQAojd7s=
-github.com/ONSdigital/graphson v0.1.1-0.20210317162900-dbbc920ad87a/go.mod h1:IRS8d1ydh1oczDKbLhTcqc/BNfgZyzhrrjr21SQOkjA=
+github.com/ONSdigital/graphson v0.2.0 h1:NxyMTa8oyxxj/u2Ee95wdBkru91jO7aMyXxz4G9i95U=
+github.com/ONSdigital/graphson v0.2.0/go.mod h1:b+Xb2Tp3/Q6BelIgYLQTM1dO10i2jDwIOtTKt5KPcOI=
 github.com/ONSdigital/gremgo-neptune v1.0.1 h1:2IFocPqHsWZhlzFBsXpBEYfDaw3zQiGjRajVfQ+b2A4=
 github.com/ONSdigital/gremgo-neptune v1.0.1/go.mod h1:GZz/N6xjNY+EN0x4FmfBDrM73R+Pr3aI5iCwYbY1oYQ=
 github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20/go.mod h1:BD7D8FWP1fzwUWsrCopEG72jl9cchCaVNIGSz6YvL+Y=
@@ -144,6 +144,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670 h1:gzMM0EjIYiRmJI3+jBdFuoynZlpxa2JQZsolKu09BXo=
+golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -153,6 +155,8 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -165,6 +169,9 @@ golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.34.2 h1:4oVv0YbpxZn4V1H/X7RFQqlAPdXBlthKTarvrDq+tbU=
 github.com/ONSdigital/dp-api-clients-go v1.34.2/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
-github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210316112733-2e074664dc6b h1:7zZTBJYxMqKkQh4I60aJi8dmpLNGXUh3DrdT4FCigb4=
-github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210316112733-2e074664dc6b/go.mod h1:GiBi5XwMQf7Yu/yD2MssdsFD8Tmi64xQfWLPVrH7SDs=
+github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210317122038-a3e2f1c282a2 h1:Jt9LlrRW/WLwI0druTOR95+6JKx9Sg60KdclEseK3pM=
+github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210317122038-a3e2f1c282a2/go.mod h1:+m3RdJJj3MsqcufyalJVuzI5rhPmlvw6Tto/ppi4AEQ=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.34.2 h1:4oVv0YbpxZn4V1H/X7RFQqlAPdXBlthKTarvrDq+tbU=
 github.com/ONSdigital/dp-api-clients-go v1.34.2/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
-github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210317122038-a3e2f1c282a2 h1:Jt9LlrRW/WLwI0druTOR95+6JKx9Sg60KdclEseK3pM=
-github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210317122038-a3e2f1c282a2/go.mod h1:+m3RdJJj3MsqcufyalJVuzI5rhPmlvw6Tto/ppi4AEQ=
+github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210317134336-6842b583aef5 h1:zo5en2C13FF3sPjYzydGNKBDM+B4mu0SGUdHMEOu0DU=
+github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210317134336-6842b583aef5/go.mod h1:+m3RdJJj3MsqcufyalJVuzI5rhPmlvw6Tto/ppi4AEQ=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.34.2 h1:4oVv0YbpxZn4V1H/X7RFQqlAPdXBlthKTarvrDq+tbU=
 github.com/ONSdigital/dp-api-clients-go v1.34.2/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
-github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210317134336-6842b583aef5 h1:zo5en2C13FF3sPjYzydGNKBDM+B4mu0SGUdHMEOu0DU=
-github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210317134336-6842b583aef5/go.mod h1:+m3RdJJj3MsqcufyalJVuzI5rhPmlvw6Tto/ppi4AEQ=
+github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210318094659-fdf21a061938 h1:KV4EGVyuZmgLXwXjCs20X8YjUNuBuKTgah6uLnFAHR8=
+github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210318094659-fdf21a061938/go.mod h1:HqPhOmhl65ApBfbILV+mgMtAh0/45BowpZWKVzxe8tM=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
@@ -32,8 +32,8 @@ github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531
 github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531d/go.mod h1:75Sxr59AMz2RiPskqSymLFxdeaIEhnkNaJE5lonMS3M=
 github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d h1:yrCtEGlohmA3OnXtke0nOOp/m9O83orpSnTGOfYOw1Q=
 github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d/go.mod h1:zQ+8pTnCLGuy4eUek81pWUxZo4/f71ri3VYz97Wby+4=
-github.com/ONSdigital/graphson v0.1.1-0.20210315170650-a0fc5edb3d84 h1:XBt89d+PWDKD3VK9EGe6JRPD9vxSR4sLRb0lpDQNTlI=
-github.com/ONSdigital/graphson v0.1.1-0.20210315170650-a0fc5edb3d84/go.mod h1:IRS8d1ydh1oczDKbLhTcqc/BNfgZyzhrrjr21SQOkjA=
+github.com/ONSdigital/graphson v0.1.1-0.20210317162900-dbbc920ad87a h1:K1Wu0HnkacG4HieNqEkLg8z7Nv2zz0PCbXDVQAojd7s=
+github.com/ONSdigital/graphson v0.1.1-0.20210317162900-dbbc920ad87a/go.mod h1:IRS8d1ydh1oczDKbLhTcqc/BNfgZyzhrrjr21SQOkjA=
 github.com/ONSdigital/gremgo-neptune v1.0.1 h1:2IFocPqHsWZhlzFBsXpBEYfDaw3zQiGjRajVfQ+b2A4=
 github.com/ONSdigital/gremgo-neptune v1.0.1/go.mod h1:GZz/N6xjNY+EN0x4FmfBDrM73R+Pr3aI5iCwYbY1oYQ=
 github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20/go.mod h1:BD7D8FWP1fzwUWsrCopEG72jl9cchCaVNIGSz6YvL+Y=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.34.2 h1:4oVv0YbpxZn4V1H/X7RFQqlAPdXBlthKTarvrDq+tbU=
 github.com/ONSdigital/dp-api-clients-go v1.34.2/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
-github.com/ONSdigital/dp-graph/v2 v2.7.4-0.20210312123934-fccf43d50e72 h1:TgSvcjCIY/boqizev88wk92ZZ/Enni7A7AseqrEyLOQ=
-github.com/ONSdigital/dp-graph/v2 v2.7.4-0.20210312123934-fccf43d50e72/go.mod h1:rblOFvTT+lMas8Y2DvoQdDL/6/EyfLLjnvL1rJnpPgg=
+github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210316112733-2e074664dc6b h1:7zZTBJYxMqKkQh4I60aJi8dmpLNGXUh3DrdT4FCigb4=
+github.com/ONSdigital/dp-graph/v2 v2.7.3-0.20210316112733-2e074664dc6b/go.mod h1:GiBi5XwMQf7Yu/yD2MssdsFD8Tmi64xQfWLPVrH7SDs=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
@@ -32,8 +32,8 @@ github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531
 github.com/ONSdigital/golang-neo4j-bolt-driver v0.0.0-20190228153339-da534111531d/go.mod h1:75Sxr59AMz2RiPskqSymLFxdeaIEhnkNaJE5lonMS3M=
 github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d h1:yrCtEGlohmA3OnXtke0nOOp/m9O83orpSnTGOfYOw1Q=
 github.com/ONSdigital/graphson v0.0.0-20190718134034-c13ceacd109d/go.mod h1:zQ+8pTnCLGuy4eUek81pWUxZo4/f71ri3VYz97Wby+4=
-github.com/ONSdigital/graphson v0.1.0 h1:Z+9l9RGnSG5OU5sx/QanLEfhrHGqY+hni+7NJ2TLFAY=
-github.com/ONSdigital/graphson v0.1.0/go.mod h1:IRS8d1ydh1oczDKbLhTcqc/BNfgZyzhrrjr21SQOkjA=
+github.com/ONSdigital/graphson v0.1.1-0.20210315170650-a0fc5edb3d84 h1:XBt89d+PWDKD3VK9EGe6JRPD9vxSR4sLRb0lpDQNTlI=
+github.com/ONSdigital/graphson v0.1.1-0.20210315170650-a0fc5edb3d84/go.mod h1:IRS8d1ydh1oczDKbLhTcqc/BNfgZyzhrrjr21SQOkjA=
 github.com/ONSdigital/gremgo-neptune v1.0.1 h1:2IFocPqHsWZhlzFBsXpBEYfDaw3zQiGjRajVfQ+b2A4=
 github.com/ONSdigital/gremgo-neptune v1.0.1/go.mod h1:GZz/N6xjNY+EN0x4FmfBDrM73R+Pr3aI5iCwYbY1oYQ=
 github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20/go.mod h1:BD7D8FWP1fzwUWsrCopEG72jl9cchCaVNIGSz6YvL+Y=

--- a/handler/incoming_instance_handler.go
+++ b/handler/incoming_instance_handler.go
@@ -168,7 +168,7 @@ func (hdlr *InstanceEventHandler) insertDimension(ctx context.Context, cache map
 		return
 	}
 
-	order, err := hdlr.Store.GetCodeOrder(ctx, d.CodeListID(), d.DbModel().Option)
+	orderMap, err := hdlr.Store.GetCodesOrder(ctx, d.CodeListID(), []string{d.DbModel().Option})
 	if err != nil {
 		err = errors.Wrap(err, "error while attempting to get dimension order")
 		log.Event(ctx, err.Error(), log.Error(err), log.Data{
@@ -181,7 +181,7 @@ func (hdlr *InstanceEventHandler) insertDimension(ctx context.Context, cache map
 		return
 	}
 
-	if err = hdlr.DatasetAPICli.PatchDimensionOption(ctx, instance.DbModel().InstanceID, d, order); err != nil {
+	if err = hdlr.DatasetAPICli.PatchDimensionOption(ctx, instance.DbModel().InstanceID, d, orderMap[d.DbModel().Option]); err != nil {
 		err = errors.Wrap(err, "DatasetAPICli.PatchDimensionOption returned an error")
 		log.Event(ctx, err.Error(), log.Error(err), log.Data{"instance_id": instance.DbModel().InstanceID, "dimension_id": dbDimension.DimensionID})
 		problem <- err

--- a/handler/incoming_instance_handler_test.go
+++ b/handler/incoming_instance_handler_test.go
@@ -333,6 +333,9 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 			storerMock.GetCodesOrderFunc = func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
 				return nil, errorMock
 			}
+			storerMock.GetCodeOrderFunc = func(ctx context.Context, codeListID string, codeLabel string) (*int, error) {
+				return nil, errorMock
+			}
 
 			err := handler.Handle(ctx, event)
 
@@ -366,7 +369,7 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 			})
 
 			Convey("And the expected error is returned", func() {
-				So(err.Error(), ShouldEqual, errors.Wrap(errorMock, "error while attempting to get dimension order").Error())
+				So(err.Error(), ShouldEqual, errors.Wrap(errorMock, "error while attempting to get dimension order using label").Error())
 			})
 
 			Convey("And no further processing of the event takes place.", func() {

--- a/handler/incoming_instance_handler_test.go
+++ b/handler/incoming_instance_handler_test.go
@@ -99,13 +99,13 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 			})
 
 			Convey("And storerMock.GetCodeOrder is called 2 times with the expected paramters", func() {
-				calls := storerMock.GetCodeOrderCalls()
+				calls := storerMock.GetCodesOrderCalls()
 				So(len(calls), ShouldEqual, 2)
 
 				So(calls[0].CodeListID, ShouldEqual, testCodeListID)
 				So(calls[1].CodeListID, ShouldEqual, testCodeListID)
-				So(calls[0].CodeLabel, ShouldEqual, d1Api.Option)
-				So(calls[1].CodeLabel, ShouldEqual, d2Api.Option)
+				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option})
+				So(calls[1].Codes, ShouldResemble, []string{d2Api.Option})
 			})
 
 			Convey("And DatasetAPICli.PatchDimensionOption is called 2 times with the expected parameters", func() {
@@ -156,7 +156,7 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 
 			Convey("And no further processing of the event takes place.", func() {
 				So(len(storerMock.InsertDimensionCalls()), ShouldEqual, 0)
-				So(len(storerMock.GetCodeOrderCalls()), ShouldEqual, 0)
+				So(len(storerMock.GetCodesOrderCalls()), ShouldEqual, 0)
 				So(len(datasetAPIMock.GetInstanceDimensionsCalls()), ShouldEqual, 0)
 				So(len(datasetAPIMock.PatchInstanceDimensionOptionCalls()), ShouldEqual, 0)
 				So(len(storerMock.CreateInstanceCalls()), ShouldEqual, 0)
@@ -187,7 +187,7 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 
 			Convey("And no further processing of the event takes place.", func() {
 				So(len(storerMock.InsertDimensionCalls()), ShouldEqual, 0)
-				So(len(storerMock.GetCodeOrderCalls()), ShouldEqual, 0)
+				So(len(storerMock.GetCodesOrderCalls()), ShouldEqual, 0)
 				So(len(datasetAPIMock.PatchInstanceDimensionOptionCalls()), ShouldEqual, 0)
 				So(len(storerMock.CreateInstanceCalls()), ShouldEqual, 0)
 				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
@@ -219,7 +219,7 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 
 			Convey("And no further processing of the event takes place.", func() {
 				So(len(storerMock.InsertDimensionCalls()), ShouldEqual, 0)
-				So(len(storerMock.GetCodeOrderCalls()), ShouldEqual, 0)
+				So(len(storerMock.GetCodesOrderCalls()), ShouldEqual, 0)
 				So(len(datasetAPIMock.PatchInstanceDimensionOptionCalls()), ShouldEqual, 0)
 				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
 			})
@@ -260,11 +260,11 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 			})
 
 			Convey("And storerMock.GetCodeOrder is called 2 times with the expected paramters", func() {
-				calls := storerMock.GetCodeOrderCalls()
+				calls := storerMock.GetCodesOrderCalls()
 				So(len(calls), ShouldBeGreaterThan, 0)
 
 				So(calls[0].CodeListID, ShouldEqual, testCodeListID)
-				So(calls[0].CodeLabel, ShouldEqual, d1Api.Option)
+				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option})
 			})
 
 			Convey("And DatasetAPICli.PatchDimensionOption is at least once with the expected parameters", func() {
@@ -318,19 +318,19 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 			})
 
 			Convey("And no further processing of the event takes place.", func() {
-				So(len(storerMock.GetCodeOrderCalls()), ShouldEqual, 0)
+				So(len(storerMock.GetCodesOrderCalls()), ShouldEqual, 0)
 				So(len(datasetAPIMock.PatchInstanceDimensionOptionCalls()), ShouldEqual, 0)
 				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
 			})
 		})
 
-		Convey("When storer.GetCodeOrder returns an error", func() {
+		Convey("When storer.GetCodesOrder returns an error", func() {
 			event := event.NewInstance{InstanceID: testInstanceID}
 
 			storerMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
 				return dimension, nil
 			}
-			storerMock.GetCodeOrderFunc = func(ctx context.Context, codeListID string, code string) (*int, error) {
+			storerMock.GetCodesOrderFunc = func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
 				return nil, errorMock
 			}
 
@@ -357,12 +357,12 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 				So(calls[0].Dimension, ShouldResemble, d1.DbModel())
 			})
 
-			Convey("And storerMock.GetCodeOrder is called 2 times with the expected paramters", func() {
-				calls := storerMock.GetCodeOrderCalls()
+			Convey("And storerMock.GetCodesOrder is called 2 times with the expected paramters", func() {
+				calls := storerMock.GetCodesOrderCalls()
 				So(len(calls), ShouldBeGreaterThan, 0)
 
 				So(calls[0].CodeListID, ShouldEqual, testCodeListID)
-				So(calls[0].CodeLabel, ShouldEqual, d1Api.Option)
+				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option})
 			})
 
 			Convey("And the expected error is returned", func() {
@@ -409,11 +409,11 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 			})
 
 			Convey("And storerMock.GetCodeOrder is called 2 times with the expected paramters", func() {
-				calls := storerMock.GetCodeOrderCalls()
+				calls := storerMock.GetCodesOrderCalls()
 				So(len(calls), ShouldBeGreaterThan, 0)
 
 				So(calls[0].CodeListID, ShouldEqual, testCodeListID)
-				So(calls[0].CodeLabel, ShouldEqual, d1Api.Option)
+				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option})
 			})
 
 			Convey("And DatasetAPICli.PatchDimensionOption is called at least once with the expected parameters", func() {
@@ -473,13 +473,13 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 			})
 
 			Convey("And storerMock.GetCodeOrder is called 2 times with the expected paramters", func() {
-				calls := storerMock.GetCodeOrderCalls()
+				calls := storerMock.GetCodesOrderCalls()
 				So(len(calls), ShouldEqual, 2)
 
 				So(calls[0].CodeListID, ShouldEqual, testCodeListID)
 				So(calls[1].CodeListID, ShouldEqual, testCodeListID)
-				So(calls[0].CodeLabel, ShouldEqual, d1Api.Option)
-				So(calls[1].CodeLabel, ShouldEqual, d2Api.Option)
+				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option})
+				So(calls[1].Codes, ShouldResemble, []string{d2Api.Option})
 			})
 
 			Convey("And DatasetAPICli.PatchDimensionOption is called 1 time with the expected parameters", func() {
@@ -625,7 +625,7 @@ func TestInstanceEventHandler_Handle_InstanceExistsErr(t *testing.T) {
 				So(storerMock.InstanceExistsCalls()[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
 				So(len(storerMock.CreateInstanceCalls()), ShouldEqual, 0)
 				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
-				So(len(storerMock.GetCodeOrderCalls()), ShouldEqual, 0)
+				So(len(storerMock.GetCodesOrderCalls()), ShouldEqual, 0)
 				So(len(storerMock.InsertDimensionCalls()), ShouldEqual, 0)
 				So(len(storerMock.CreateInstanceConstraintCalls()), ShouldEqual, 0)
 			})
@@ -661,6 +661,9 @@ func setUp() (*storertest.StorerMock, *mocks.IClientMock, *mocks.CompletedProduc
 		},
 		GetCodeOrderFunc: func(ctx context.Context, codeListID string, code string) (*int, error) {
 			return nil, nil
+		},
+		GetCodesOrderFunc: func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
+			return map[string]*int{}, nil
 		},
 		CloseFunc: func(ctx context.Context) error {
 			// Do nothing.

--- a/store/store.go
+++ b/store/store.go
@@ -18,6 +18,7 @@ type Storer interface {
 	InstanceExists(ctx context.Context, instanceID string) (bool, error)
 	InsertDimension(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error)
 	GetCodeOrder(ctx context.Context, codeListID, codeLabel string) (order *int, err error)
+	GetCodesOrder(ctx context.Context, codeListID string, codes []string) (codeOrders map[string]*int, err error)
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
 	Close(ctx context.Context) error
 	ErrorChan() chan error

--- a/store/store.go
+++ b/store/store.go
@@ -17,7 +17,6 @@ type Storer interface {
 	CreateCodeRelationship(ctx context.Context, instanceID, codeListID, code string) error
 	InstanceExists(ctx context.Context, instanceID string) (bool, error)
 	InsertDimension(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error)
-	GetCodeOrder(ctx context.Context, codeListID, codeLabel string) (order *int, err error)
 	GetCodesOrder(ctx context.Context, codeListID string, codes []string) (codeOrders map[string]*int, err error)
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
 	Close(ctx context.Context) error

--- a/store/storertest/storer.go
+++ b/store/storertest/storer.go
@@ -19,7 +19,6 @@ var (
 	lockStorerMockCreateInstance           sync.RWMutex
 	lockStorerMockCreateInstanceConstraint sync.RWMutex
 	lockStorerMockErrorChan                sync.RWMutex
-	lockStorerMockGetCodeOrder             sync.RWMutex
 	lockStorerMockGetCodesOrder            sync.RWMutex
 	lockStorerMockInsertDimension          sync.RWMutex
 	lockStorerMockInstanceExists           sync.RWMutex
@@ -55,9 +54,6 @@ var _ store.Storer = &StorerMock{}
 //             },
 //             ErrorChanFunc: func() chan error {
 // 	               panic("mock out the ErrorChan method")
-//             },
-//             GetCodeOrderFunc: func(ctx context.Context, codeListID string, codeLabel string) (*int, error) {
-// 	               panic("mock out the GetCodeOrder method")
 //             },
 //             GetCodesOrderFunc: func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
 // 	               panic("mock out the GetCodesOrder method")
@@ -95,9 +91,6 @@ type StorerMock struct {
 
 	// ErrorChanFunc mocks the ErrorChan method.
 	ErrorChanFunc func() chan error
-
-	// GetCodeOrderFunc mocks the GetCodeOrder method.
-	GetCodeOrderFunc func(ctx context.Context, codeListID string, codeLabel string) (*int, error)
 
 	// GetCodesOrderFunc mocks the GetCodesOrder method.
 	GetCodesOrderFunc func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error)
@@ -160,15 +153,6 @@ type StorerMock struct {
 		}
 		// ErrorChan holds details about calls to the ErrorChan method.
 		ErrorChan []struct {
-		}
-		// GetCodeOrder holds details about calls to the GetCodeOrder method.
-		GetCodeOrder []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// CodeListID is the codeListID argument value.
-			CodeListID string
-			// CodeLabel is the codeLabel argument value.
-			CodeLabel string
 		}
 		// GetCodesOrder holds details about calls to the GetCodesOrder method.
 		GetCodesOrder []struct {
@@ -445,45 +429,6 @@ func (mock *StorerMock) ErrorChanCalls() []struct {
 	lockStorerMockErrorChan.RLock()
 	calls = mock.calls.ErrorChan
 	lockStorerMockErrorChan.RUnlock()
-	return calls
-}
-
-// GetCodeOrder calls GetCodeOrderFunc.
-func (mock *StorerMock) GetCodeOrder(ctx context.Context, codeListID string, codeLabel string) (*int, error) {
-	if mock.GetCodeOrderFunc == nil {
-		panic("StorerMock.GetCodeOrderFunc: method is nil but Storer.GetCodeOrder was just called")
-	}
-	callInfo := struct {
-		Ctx        context.Context
-		CodeListID string
-		CodeLabel  string
-	}{
-		Ctx:        ctx,
-		CodeListID: codeListID,
-		CodeLabel:  codeLabel,
-	}
-	lockStorerMockGetCodeOrder.Lock()
-	mock.calls.GetCodeOrder = append(mock.calls.GetCodeOrder, callInfo)
-	lockStorerMockGetCodeOrder.Unlock()
-	return mock.GetCodeOrderFunc(ctx, codeListID, codeLabel)
-}
-
-// GetCodeOrderCalls gets all the calls that were made to GetCodeOrder.
-// Check the length with:
-//     len(mockedStorer.GetCodeOrderCalls())
-func (mock *StorerMock) GetCodeOrderCalls() []struct {
-	Ctx        context.Context
-	CodeListID string
-	CodeLabel  string
-} {
-	var calls []struct {
-		Ctx        context.Context
-		CodeListID string
-		CodeLabel  string
-	}
-	lockStorerMockGetCodeOrder.RLock()
-	calls = mock.calls.GetCodeOrder
-	lockStorerMockGetCodeOrder.RUnlock()
 	return calls
 }
 

--- a/store/storertest/storer.go
+++ b/store/storertest/storer.go
@@ -20,6 +20,7 @@ var (
 	lockStorerMockCreateInstanceConstraint sync.RWMutex
 	lockStorerMockErrorChan                sync.RWMutex
 	lockStorerMockGetCodeOrder             sync.RWMutex
+	lockStorerMockGetCodesOrder            sync.RWMutex
 	lockStorerMockInsertDimension          sync.RWMutex
 	lockStorerMockInstanceExists           sync.RWMutex
 )
@@ -58,6 +59,9 @@ var _ store.Storer = &StorerMock{}
 //             GetCodeOrderFunc: func(ctx context.Context, codeListID string, codeLabel string) (*int, error) {
 // 	               panic("mock out the GetCodeOrder method")
 //             },
+//             GetCodesOrderFunc: func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
+// 	               panic("mock out the GetCodesOrder method")
+//             },
 //             InsertDimensionFunc: func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
 // 	               panic("mock out the InsertDimension method")
 //             },
@@ -94,6 +98,9 @@ type StorerMock struct {
 
 	// GetCodeOrderFunc mocks the GetCodeOrder method.
 	GetCodeOrderFunc func(ctx context.Context, codeListID string, codeLabel string) (*int, error)
+
+	// GetCodesOrderFunc mocks the GetCodesOrder method.
+	GetCodesOrderFunc func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error)
 
 	// InsertDimensionFunc mocks the InsertDimension method.
 	InsertDimensionFunc func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error)
@@ -162,6 +169,15 @@ type StorerMock struct {
 			CodeListID string
 			// CodeLabel is the codeLabel argument value.
 			CodeLabel string
+		}
+		// GetCodesOrder holds details about calls to the GetCodesOrder method.
+		GetCodesOrder []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// CodeListID is the codeListID argument value.
+			CodeListID string
+			// Codes is the codes argument value.
+			Codes []string
 		}
 		// InsertDimension holds details about calls to the InsertDimension method.
 		InsertDimension []struct {
@@ -468,6 +484,45 @@ func (mock *StorerMock) GetCodeOrderCalls() []struct {
 	lockStorerMockGetCodeOrder.RLock()
 	calls = mock.calls.GetCodeOrder
 	lockStorerMockGetCodeOrder.RUnlock()
+	return calls
+}
+
+// GetCodesOrder calls GetCodesOrderFunc.
+func (mock *StorerMock) GetCodesOrder(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
+	if mock.GetCodesOrderFunc == nil {
+		panic("StorerMock.GetCodesOrderFunc: method is nil but Storer.GetCodesOrder was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		CodeListID string
+		Codes      []string
+	}{
+		Ctx:        ctx,
+		CodeListID: codeListID,
+		Codes:      codes,
+	}
+	lockStorerMockGetCodesOrder.Lock()
+	mock.calls.GetCodesOrder = append(mock.calls.GetCodesOrder, callInfo)
+	lockStorerMockGetCodesOrder.Unlock()
+	return mock.GetCodesOrderFunc(ctx, codeListID, codes)
+}
+
+// GetCodesOrderCalls gets all the calls that were made to GetCodesOrder.
+// Check the length with:
+//     len(mockedStorer.GetCodesOrderCalls())
+func (mock *StorerMock) GetCodesOrderCalls() []struct {
+	Ctx        context.Context
+	CodeListID string
+	Codes      []string
+} {
+	var calls []struct {
+		Ctx        context.Context
+		CodeListID string
+		Codes      []string
+	}
+	lockStorerMockGetCodesOrder.RLock()
+	calls = mock.calls.GetCodesOrder
+	lockStorerMockGetCodesOrder.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What

- Always use code instead of label to obtain the order, without any fallback.

Dependencies
It was decided that we would always use option=code, so this PR now depends on:
- https://github.com/ONSdigital/dp-dimension-extractor/pull/77
- https://github.com/ONSdigital/dp-observation-importer/pull/80


### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (info) Tested an import + filter journey locally with:
  - observation importer using `feature/always-use-code` branch
  - dimension extractor using `feature/always-use-code` branch
  - dimension importer using `fix/use-codes-for-order` branch

### Who can review

Anyone, but I would suggest @CarlHembrough
