### PR TITLE
use latest version of dp-graph to fix the gremgo response handing bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.34.2
-	github.com/ONSdigital/dp-graph/v2 v2.9.0
+	github.com/ONSdigital/dp-graph/v2 v2.11.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.1.2
 	github.com/ONSdigital/dp-net v1.0.12

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.2/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-graph/v2 v2.9.0 h1:S3zNRfzjApPRV23EC/EhclaLZ02u5V/RVSdO3q3rdgA=
 github.com/ONSdigital/dp-graph/v2 v2.9.0/go.mod h1:bhiKBX0l62HWaYMN4d6vjldayPTGB3fd7W4kVqNsiwU=
+github.com/ONSdigital/dp-graph/v2 v2.11.1 h1:E8w/ZKkN61CY3luP9iFGEqiZfbuboLBchD+JqFf/M7I=
+github.com/ONSdigital/dp-graph/v2 v2.11.1/go.mod h1:bhiKBX0l62HWaYMN4d6vjldayPTGB3fd7W4kVqNsiwU=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=


### PR DESCRIPTION
### What

Use latest version of `dp-graph` to fix the gremgo response handing bug. This bug did not have any effect on this service becuase we are handling one node at a time, but we need to use the bug fix in case there are some changes in the future.

### How to review

Make sure dp-graph version 2.11.1 is used

### Who can review

anyone