### PR TITLE
use fix for get instance dimensions from dp-api-clients-go

### DIFF
--- a/client/dimensions_api.go
+++ b/client/dimensions_api.go
@@ -31,7 +31,7 @@ var ErrDimensionIDEmpty = errors.New("dimension.id is required but is empty")
 // IClient is an interface that represents the required functionality from dataset client from dp-api-clients-go
 type IClient interface {
 	PatchInstanceDimensionOption(ctx context.Context, serviceAuthToken, instanceID, dimensionID, optionID, nodeID string, order *int) error
-	GetInstanceDimensionsInBatches(ctx context.Context, userAuthToken, serviceAuthToken, instanceID string, batchSize, maxWorkers int) (m dataset.Dimensions, err error)
+	GetInstanceDimensionsInBatches(ctx context.Context, serviceAuthToken, instanceID string, batchSize, maxWorkers int) (m dataset.Dimensions, err error)
 	GetInstance(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, instanceID string) (m dataset.Instance, err error)
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
 }
@@ -77,7 +77,7 @@ func (api DatasetAPI) GetDimensions(ctx context.Context, instanceID string) ([]*
 		return nil, ErrInstanceIDEmpty
 	}
 
-	dimensions, err := api.Client.GetInstanceDimensionsInBatches(ctx, "", api.AuthToken, instanceID, api.BatchSize, api.MaxWorkers)
+	dimensions, err := api.Client.GetInstanceDimensionsInBatches(ctx, api.AuthToken, instanceID, api.BatchSize, api.MaxWorkers)
 	if err != nil {
 		return nil, err
 	}

--- a/client/dimensions_api.go
+++ b/client/dimensions_api.go
@@ -56,6 +56,8 @@ func NewDatasetAPIClient(cfg *config.Config) (*DatasetAPI, error) {
 		DatasetAPIHost:    cfg.DatasetAPIAddr,
 		Client:            dataset.NewAPIClient(cfg.DatasetAPIAddr),
 		EnablePatchNodeID: cfg.EnablePatchNodeID,
+		MaxWorkers:        cfg.DatasetAPIMaxWorkers,
+		BatchSize:         cfg.DatasetAPIBatchSize,
 	}, nil
 }
 

--- a/client/dimensions_api_test.go
+++ b/client/dimensions_api_test.go
@@ -152,7 +152,7 @@ func TestGetDimensions(t *testing.T) {
 	Convey("Given a valid client configuration", t, func() {
 
 		clientMock := &mocks.IClientMock{
-			GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, userAuthToken, serviceAuthToken string, instanceID string, bacthSize, maxWorkers int) (dataset.Dimensions, error) {
+			GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, bacthSize, maxWorkers int) (dataset.Dimensions, error) {
 				return datasetDimensions, nil
 			},
 		}
@@ -204,7 +204,7 @@ func TestGetDimensions(t *testing.T) {
 	Convey("Given dataset.GetInstanceDimensions will return an error", t, func() {
 
 		clientMock := &mocks.IClientMock{
-			GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, userAuthToken, serviceAuthToken string, instanceID string, bacthSize, maxWorkers int) (dataset.Dimensions, error) {
+			GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, bacthSize, maxWorkers int) (dataset.Dimensions, error) {
 				return dataset.Dimensions{}, errMock
 			},
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -17,15 +17,17 @@ type Config struct {
 	KafkaAddr                      []string      `envconfig:"KAFKA_ADDR"`
 	KafkaVersion                   string        `envconfig:"KAFKA_VERSION"`
 	KafkaOffsetOldest              bool          `envconfig:"KAFKA_OFFSET_OLDEST"`
-	KafkaNumWorkers                int           `envconfig:"KAFKA_NUM_WORKERS"`
+	KafkaNumWorkers                int           `envconfig:"KAFKA_NUM_WORKERS"` // maximum number of concurent kafka messages being consumed at the same time
+	BatchSize                      int           `envconfig:"BATCH_SIZE"`        // Number of kafka messages that will be batched
 	IncomingInstancesTopic         string        `envconfig:"DIMENSIONS_EXTRACTED_TOPIC"`
 	IncomingInstancesConsumerGroup string        `envconfig:"DIMENSIONS_EXTRACTED_CONSUMER_GROUP"`
 	OutgoingInstancesTopic         string        `envconfig:"DIMENSIONS_INSERTED_TOPIC"`
 	EventReporterTopic             string        `envconfig:"EVENT_REPORTER_TOPIC"`
 	DatasetAPIAddr                 string        `envconfig:"DATASET_API_ADDR"`
+	DatasetAPIMaxWorkers           int           `envconfig:"DATASET_API_MAX_WORKERS"` // maximum number of concurrent go-routines requesting items to datast api at the same time
+	DatasetAPIBatchSize            int           `envconfig:"DATASET_API_BATCH_SIZE"`  // maximum size of a response by dataset api when requesting items in batches
 	GracefulShutdownTimeout        time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval            time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
-	BatchSize                      int           `envconfig:"BATCH_SIZE"`
 	HealthCheckCriticalTimeout     time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	EnablePatchNodeID              bool          `envconfig:"ENABLE_PATCH_NODE_ID"`
 }
@@ -41,19 +43,21 @@ func Get(ctx context.Context) (*Config, error) {
 	cfg := &Config{
 		BindAddr:                       ":23000",
 		ServiceAuthToken:               "4424A9F2-B903-40F4-85F1-240107D1AFAF",
-		DatasetAPIAddr:                 "http://localhost:22000",
 		KafkaAddr:                      []string{"localhost:9092"},
 		KafkaVersion:                   "1.0.2",
 		KafkaOffsetOldest:              true,
 		KafkaNumWorkers:                1,
+		BatchSize:                      1, //not all implementations will allow for batching, so set to a safe default
 		IncomingInstancesTopic:         "dimensions-extracted",
 		IncomingInstancesConsumerGroup: "dp-dimension-importer",
 		OutgoingInstancesTopic:         "dimensions-inserted",
 		EventReporterTopic:             "report-events",
+		DatasetAPIAddr:                 "http://localhost:22000",
+		DatasetAPIMaxWorkers:           100,
+		DatasetAPIBatchSize:            1000,
 		GracefulShutdownTimeout:        time.Second * 5,
 		HealthCheckInterval:            30 * time.Second,
 		HealthCheckCriticalTimeout:     90 * time.Second,
-		BatchSize:                      1, //not all implementations will allow for batching, so set to a safe default
 		EnablePatchNodeID:              true,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-dimension-importer
 go 1.16
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.36.0
+	github.com/ONSdigital/dp-api-clients-go v1.36.1-0.20210609150026-267617d7fe5a
 	github.com/ONSdigital/dp-graph/v2 v2.13.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.2.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-dimension-importer
 go 1.16
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.36.1-0.20210609150026-267617d7fe5a
+	github.com/ONSdigital/dp-api-clients-go v1.36.1
 	github.com/ONSdigital/dp-graph/v2 v2.13.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.36.0 h1:bAxGiC2rgmtvLTa5YAKJw6OyO9kZSSCDbvwUDg5r5Oc=
 github.com/ONSdigital/dp-api-clients-go v1.36.0/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
+github.com/ONSdigital/dp-api-clients-go v1.36.1-0.20210609150026-267617d7fe5a h1:mfVr3p+zjA/ENMYhd4YbkPqv9kGkiIuM48AipzAnFh4=
+github.com/ONSdigital/dp-api-clients-go v1.36.1-0.20210609150026-267617d7fe5a/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-graph/v2 v2.13.1 h1:txp2WOtmA/S3g4BzcZ2uxcSvp0nBUtZTzWjkbDrSHqs=
 github.com/ONSdigital/dp-graph/v2 v2.13.1/go.mod h1:goNf7IF+hJATF9F8DD8QAHNF38s/0wRMzgHxzOamDKo=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.36.0/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
-github.com/ONSdigital/dp-api-clients-go v1.36.1-0.20210609150026-267617d7fe5a h1:mfVr3p+zjA/ENMYhd4YbkPqv9kGkiIuM48AipzAnFh4=
-github.com/ONSdigital/dp-api-clients-go v1.36.1-0.20210609150026-267617d7fe5a/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
+github.com/ONSdigital/dp-api-clients-go v1.36.1 h1:fI4NuoE+DHYyloNEhPsXQDFoJMwftgj7GVt+H3BGwFE=
+github.com/ONSdigital/dp-api-clients-go v1.36.1/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-graph/v2 v2.13.1 h1:txp2WOtmA/S3g4BzcZ2uxcSvp0nBUtZTzWjkbDrSHqs=
 github.com/ONSdigital/dp-graph/v2 v2.13.1/go.mod h1:goNf7IF+hJATF9F8DD8QAHNF38s/0wRMzgHxzOamDKo=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=

--- a/handler/incoming_instance_handler_test.go
+++ b/handler/incoming_instance_handler_test.go
@@ -177,7 +177,7 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		Convey("When DatasetAPICli.GetInstanceDimensions returns an error", func() {
 			event := event.NewInstance{InstanceID: testInstanceID}
 
-			datasetAPIMock.GetInstanceDimensionsInBatchesFunc = func(ctx context.Context, userAuthToken, serviceAuthToken string, instanceID string, maxWorkers, batchSize int) (dataset.Dimensions, error) {
+			datasetAPIMock.GetInstanceDimensionsInBatchesFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, maxWorkers, batchSize int) (dataset.Dimensions, error) {
 				return dataset.Dimensions{}, errorMock
 			}
 
@@ -694,7 +694,7 @@ func setUp() (*storertest.StorerMock, *mocks.IClientMock, *mocks.CompletedProduc
 	}
 
 	datasetAPIMock := &mocks.IClientMock{
-		GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, userAuthToken, serviceAuthToken string, instanceID string, maxWorkers, batchSize int) (dataset.Dimensions, error) {
+		GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, maxWorkers, batchSize int) (dataset.Dimensions, error) {
 			return dataset.Dimensions{Items: []dataset.Dimension{d1Api, d2Api}}, nil
 		},
 		PatchInstanceDimensionOptionFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, dimensionID string, optionID string, nodeID string, order *int) error {

--- a/message/mock/instance_event_handler.go
+++ b/message/mock/instance_event_handler.go
@@ -10,6 +10,10 @@ import (
 	"sync"
 )
 
+var (
+	lockInstanceEventHandlerMockHandle sync.RWMutex
+)
+
 // Ensure, that InstanceEventHandlerMock does implement message.InstanceEventHandler.
 // If this is not the case, regenerate this file with moq.
 var _ message.InstanceEventHandler = &InstanceEventHandlerMock{}
@@ -43,7 +47,6 @@ type InstanceEventHandlerMock struct {
 			E event.NewInstance
 		}
 	}
-	lockHandle sync.RWMutex
 }
 
 // Handle calls HandleFunc.
@@ -58,9 +61,9 @@ func (mock *InstanceEventHandlerMock) Handle(ctx context.Context, e event.NewIns
 		Ctx: ctx,
 		E:   e,
 	}
-	mock.lockHandle.Lock()
+	lockInstanceEventHandlerMockHandle.Lock()
 	mock.calls.Handle = append(mock.calls.Handle, callInfo)
-	mock.lockHandle.Unlock()
+	lockInstanceEventHandlerMockHandle.Unlock()
 	return mock.HandleFunc(ctx, e)
 }
 
@@ -75,8 +78,8 @@ func (mock *InstanceEventHandlerMock) HandleCalls() []struct {
 		Ctx context.Context
 		E   event.NewInstance
 	}
-	mock.lockHandle.RLock()
+	lockInstanceEventHandlerMockHandle.RLock()
 	calls = mock.calls.Handle
-	mock.lockHandle.RUnlock()
+	lockInstanceEventHandlerMockHandle.RUnlock()
 	return calls
 }

--- a/message/mock/producer.go
+++ b/message/mock/producer.go
@@ -8,6 +8,10 @@ import (
 	"sync"
 )
 
+var (
+	lockMarshallerMockMarshal sync.RWMutex
+)
+
 // Ensure, that MarshallerMock does implement message.Marshaller.
 // If this is not the case, regenerate this file with moq.
 var _ message.Marshaller = &MarshallerMock{}
@@ -39,7 +43,6 @@ type MarshallerMock struct {
 			S interface{}
 		}
 	}
-	lockMarshal sync.RWMutex
 }
 
 // Marshal calls MarshalFunc.
@@ -52,9 +55,9 @@ func (mock *MarshallerMock) Marshal(s interface{}) ([]byte, error) {
 	}{
 		S: s,
 	}
-	mock.lockMarshal.Lock()
+	lockMarshallerMockMarshal.Lock()
 	mock.calls.Marshal = append(mock.calls.Marshal, callInfo)
-	mock.lockMarshal.Unlock()
+	lockMarshallerMockMarshal.Unlock()
 	return mock.MarshalFunc(s)
 }
 
@@ -67,8 +70,8 @@ func (mock *MarshallerMock) MarshalCalls() []struct {
 	var calls []struct {
 		S interface{}
 	}
-	mock.lockMarshal.RLock()
+	lockMarshallerMockMarshal.RLock()
 	calls = mock.calls.Marshal
-	mock.lockMarshal.RUnlock()
+	lockMarshallerMockMarshal.RUnlock()
 	return calls
 }

--- a/message/mock/receiver.go
+++ b/message/mock/receiver.go
@@ -9,6 +9,10 @@ import (
 	"sync"
 )
 
+var (
+	lockReceiverMockOnMessage sync.RWMutex
+)
+
 // Ensure, that ReceiverMock does implement message.Receiver.
 // If this is not the case, regenerate this file with moq.
 var _ message.Receiver = &ReceiverMock{}
@@ -40,7 +44,6 @@ type ReceiverMock struct {
 			Message kafka.Message
 		}
 	}
-	lockOnMessage sync.RWMutex
 }
 
 // OnMessage calls OnMessageFunc.
@@ -53,9 +56,9 @@ func (mock *ReceiverMock) OnMessage(message kafka.Message) {
 	}{
 		Message: message,
 	}
-	mock.lockOnMessage.Lock()
+	lockReceiverMockOnMessage.Lock()
 	mock.calls.OnMessage = append(mock.calls.OnMessage, callInfo)
-	mock.lockOnMessage.Unlock()
+	lockReceiverMockOnMessage.Unlock()
 	mock.OnMessageFunc(message)
 }
 
@@ -68,8 +71,8 @@ func (mock *ReceiverMock) OnMessageCalls() []struct {
 	var calls []struct {
 		Message kafka.Message
 	}
-	mock.lockOnMessage.RLock()
+	lockReceiverMockOnMessage.RLock()
 	calls = mock.calls.OnMessage
-	mock.lockOnMessage.RUnlock()
+	lockReceiverMockOnMessage.RUnlock()
 	return calls
 }

--- a/mocks/dataset.go
+++ b/mocks/dataset.go
@@ -11,6 +11,13 @@ import (
 	"sync"
 )
 
+var (
+	lockIClientMockChecker                        sync.RWMutex
+	lockIClientMockGetInstance                    sync.RWMutex
+	lockIClientMockGetInstanceDimensionsInBatches sync.RWMutex
+	lockIClientMockPatchInstanceDimensionOption   sync.RWMutex
+)
+
 // Ensure, that IClientMock does implement client.IClient.
 // If this is not the case, regenerate this file with moq.
 var _ client.IClient = &IClientMock{}
@@ -27,7 +34,7 @@ var _ client.IClient = &IClientMock{}
 //             GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string) (dataset.Instance, error) {
 // 	               panic("mock out the GetInstance method")
 //             },
-//             GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, instanceID string, batchSize int, maxWorkers int) (dataset.Dimensions, error) {
+//             GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, batchSize int, maxWorkers int) (dataset.Dimensions, error) {
 // 	               panic("mock out the GetInstanceDimensionsInBatches method")
 //             },
 //             PatchInstanceDimensionOptionFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, dimensionID string, optionID string, nodeID string, order *int) error {
@@ -47,7 +54,7 @@ type IClientMock struct {
 	GetInstanceFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string) (dataset.Instance, error)
 
 	// GetInstanceDimensionsInBatchesFunc mocks the GetInstanceDimensionsInBatches method.
-	GetInstanceDimensionsInBatchesFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, instanceID string, batchSize int, maxWorkers int) (dataset.Dimensions, error)
+	GetInstanceDimensionsInBatchesFunc func(ctx context.Context, serviceAuthToken string, instanceID string, batchSize int, maxWorkers int) (dataset.Dimensions, error)
 
 	// PatchInstanceDimensionOptionFunc mocks the PatchInstanceDimensionOption method.
 	PatchInstanceDimensionOptionFunc func(ctx context.Context, serviceAuthToken string, instanceID string, dimensionID string, optionID string, nodeID string, order *int) error
@@ -78,8 +85,6 @@ type IClientMock struct {
 		GetInstanceDimensionsInBatches []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// UserAuthToken is the userAuthToken argument value.
-			UserAuthToken string
 			// ServiceAuthToken is the serviceAuthToken argument value.
 			ServiceAuthToken string
 			// InstanceID is the instanceID argument value.
@@ -107,10 +112,6 @@ type IClientMock struct {
 			Order *int
 		}
 	}
-	lockChecker                        sync.RWMutex
-	lockGetInstance                    sync.RWMutex
-	lockGetInstanceDimensionsInBatches sync.RWMutex
-	lockPatchInstanceDimensionOption   sync.RWMutex
 }
 
 // Checker calls CheckerFunc.
@@ -125,9 +126,9 @@ func (mock *IClientMock) Checker(ctx context.Context, state *healthcheck.CheckSt
 		Ctx:   ctx,
 		State: state,
 	}
-	mock.lockChecker.Lock()
+	lockIClientMockChecker.Lock()
 	mock.calls.Checker = append(mock.calls.Checker, callInfo)
-	mock.lockChecker.Unlock()
+	lockIClientMockChecker.Unlock()
 	return mock.CheckerFunc(ctx, state)
 }
 
@@ -142,9 +143,9 @@ func (mock *IClientMock) CheckerCalls() []struct {
 		Ctx   context.Context
 		State *healthcheck.CheckState
 	}
-	mock.lockChecker.RLock()
+	lockIClientMockChecker.RLock()
 	calls = mock.calls.Checker
-	mock.lockChecker.RUnlock()
+	lockIClientMockChecker.RUnlock()
 	return calls
 }
 
@@ -166,9 +167,9 @@ func (mock *IClientMock) GetInstance(ctx context.Context, userAuthToken string, 
 		CollectionID:     collectionID,
 		InstanceID:       instanceID,
 	}
-	mock.lockGetInstance.Lock()
+	lockIClientMockGetInstance.Lock()
 	mock.calls.GetInstance = append(mock.calls.GetInstance, callInfo)
-	mock.lockGetInstance.Unlock()
+	lockIClientMockGetInstance.Unlock()
 	return mock.GetInstanceFunc(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID)
 }
 
@@ -189,36 +190,34 @@ func (mock *IClientMock) GetInstanceCalls() []struct {
 		CollectionID     string
 		InstanceID       string
 	}
-	mock.lockGetInstance.RLock()
+	lockIClientMockGetInstance.RLock()
 	calls = mock.calls.GetInstance
-	mock.lockGetInstance.RUnlock()
+	lockIClientMockGetInstance.RUnlock()
 	return calls
 }
 
 // GetInstanceDimensionsInBatches calls GetInstanceDimensionsInBatchesFunc.
-func (mock *IClientMock) GetInstanceDimensionsInBatches(ctx context.Context, userAuthToken string, serviceAuthToken string, instanceID string, batchSize int, maxWorkers int) (dataset.Dimensions, error) {
+func (mock *IClientMock) GetInstanceDimensionsInBatches(ctx context.Context, serviceAuthToken string, instanceID string, batchSize int, maxWorkers int) (dataset.Dimensions, error) {
 	if mock.GetInstanceDimensionsInBatchesFunc == nil {
 		panic("IClientMock.GetInstanceDimensionsInBatchesFunc: method is nil but IClient.GetInstanceDimensionsInBatches was just called")
 	}
 	callInfo := struct {
 		Ctx              context.Context
-		UserAuthToken    string
 		ServiceAuthToken string
 		InstanceID       string
 		BatchSize        int
 		MaxWorkers       int
 	}{
 		Ctx:              ctx,
-		UserAuthToken:    userAuthToken,
 		ServiceAuthToken: serviceAuthToken,
 		InstanceID:       instanceID,
 		BatchSize:        batchSize,
 		MaxWorkers:       maxWorkers,
 	}
-	mock.lockGetInstanceDimensionsInBatches.Lock()
+	lockIClientMockGetInstanceDimensionsInBatches.Lock()
 	mock.calls.GetInstanceDimensionsInBatches = append(mock.calls.GetInstanceDimensionsInBatches, callInfo)
-	mock.lockGetInstanceDimensionsInBatches.Unlock()
-	return mock.GetInstanceDimensionsInBatchesFunc(ctx, userAuthToken, serviceAuthToken, instanceID, batchSize, maxWorkers)
+	lockIClientMockGetInstanceDimensionsInBatches.Unlock()
+	return mock.GetInstanceDimensionsInBatchesFunc(ctx, serviceAuthToken, instanceID, batchSize, maxWorkers)
 }
 
 // GetInstanceDimensionsInBatchesCalls gets all the calls that were made to GetInstanceDimensionsInBatches.
@@ -226,7 +225,6 @@ func (mock *IClientMock) GetInstanceDimensionsInBatches(ctx context.Context, use
 //     len(mockedIClient.GetInstanceDimensionsInBatchesCalls())
 func (mock *IClientMock) GetInstanceDimensionsInBatchesCalls() []struct {
 	Ctx              context.Context
-	UserAuthToken    string
 	ServiceAuthToken string
 	InstanceID       string
 	BatchSize        int
@@ -234,15 +232,14 @@ func (mock *IClientMock) GetInstanceDimensionsInBatchesCalls() []struct {
 } {
 	var calls []struct {
 		Ctx              context.Context
-		UserAuthToken    string
 		ServiceAuthToken string
 		InstanceID       string
 		BatchSize        int
 		MaxWorkers       int
 	}
-	mock.lockGetInstanceDimensionsInBatches.RLock()
+	lockIClientMockGetInstanceDimensionsInBatches.RLock()
 	calls = mock.calls.GetInstanceDimensionsInBatches
-	mock.lockGetInstanceDimensionsInBatches.RUnlock()
+	lockIClientMockGetInstanceDimensionsInBatches.RUnlock()
 	return calls
 }
 
@@ -268,9 +265,9 @@ func (mock *IClientMock) PatchInstanceDimensionOption(ctx context.Context, servi
 		NodeID:           nodeID,
 		Order:            order,
 	}
-	mock.lockPatchInstanceDimensionOption.Lock()
+	lockIClientMockPatchInstanceDimensionOption.Lock()
 	mock.calls.PatchInstanceDimensionOption = append(mock.calls.PatchInstanceDimensionOption, callInfo)
-	mock.lockPatchInstanceDimensionOption.Unlock()
+	lockIClientMockPatchInstanceDimensionOption.Unlock()
 	return mock.PatchInstanceDimensionOptionFunc(ctx, serviceAuthToken, instanceID, dimensionID, optionID, nodeID, order)
 }
 
@@ -295,8 +292,8 @@ func (mock *IClientMock) PatchInstanceDimensionOptionCalls() []struct {
 		NodeID           string
 		Order            *int
 	}
-	mock.lockPatchInstanceDimensionOption.RLock()
+	lockIClientMockPatchInstanceDimensionOption.RLock()
 	calls = mock.calls.PatchInstanceDimensionOption
-	mock.lockPatchInstanceDimensionOption.RUnlock()
+	lockIClientMockPatchInstanceDimensionOption.RUnlock()
 	return calls
 }

--- a/mocks/incoming_instance_generated_mocks.go
+++ b/mocks/incoming_instance_generated_mocks.go
@@ -10,6 +10,10 @@ import (
 	"sync"
 )
 
+var (
+	lockCompletedProducerMockCompleted sync.RWMutex
+)
+
 // Ensure, that CompletedProducerMock does implement handler.CompletedProducer.
 // If this is not the case, regenerate this file with moq.
 var _ handler.CompletedProducer = &CompletedProducerMock{}
@@ -43,7 +47,6 @@ type CompletedProducerMock struct {
 			E event.InstanceCompleted
 		}
 	}
-	lockCompleted sync.RWMutex
 }
 
 // Completed calls CompletedFunc.
@@ -58,9 +61,9 @@ func (mock *CompletedProducerMock) Completed(ctx context.Context, e event.Instan
 		Ctx: ctx,
 		E:   e,
 	}
-	mock.lockCompleted.Lock()
+	lockCompletedProducerMockCompleted.Lock()
 	mock.calls.Completed = append(mock.calls.Completed, callInfo)
-	mock.lockCompleted.Unlock()
+	lockCompletedProducerMockCompleted.Unlock()
 	return mock.CompletedFunc(ctx, e)
 }
 
@@ -75,8 +78,8 @@ func (mock *CompletedProducerMock) CompletedCalls() []struct {
 		Ctx context.Context
 		E   event.InstanceCompleted
 	}
-	mock.lockCompleted.RLock()
+	lockCompletedProducerMockCompleted.RLock()
 	calls = mock.calls.Completed
-	mock.lockCompleted.RUnlock()
+	lockCompletedProducerMockCompleted.RUnlock()
 	return calls
 }

--- a/store/storertest/storer.go
+++ b/store/storertest/storer.go
@@ -11,6 +11,19 @@ import (
 	"sync"
 )
 
+var (
+	lockStorerMockAddDimensions            sync.RWMutex
+	lockStorerMockChecker                  sync.RWMutex
+	lockStorerMockClose                    sync.RWMutex
+	lockStorerMockCreateCodeRelationship   sync.RWMutex
+	lockStorerMockCreateInstance           sync.RWMutex
+	lockStorerMockCreateInstanceConstraint sync.RWMutex
+	lockStorerMockErrorChan                sync.RWMutex
+	lockStorerMockGetCodesOrder            sync.RWMutex
+	lockStorerMockInsertDimension          sync.RWMutex
+	lockStorerMockInstanceExists           sync.RWMutex
+)
+
 // Ensure, that StorerMock does implement store.Storer.
 // If this is not the case, regenerate this file with moq.
 var _ store.Storer = &StorerMock{}
@@ -169,16 +182,6 @@ type StorerMock struct {
 			InstanceID string
 		}
 	}
-	lockAddDimensions            sync.RWMutex
-	lockChecker                  sync.RWMutex
-	lockClose                    sync.RWMutex
-	lockCreateCodeRelationship   sync.RWMutex
-	lockCreateInstance           sync.RWMutex
-	lockCreateInstanceConstraint sync.RWMutex
-	lockErrorChan                sync.RWMutex
-	lockGetCodesOrder            sync.RWMutex
-	lockInsertDimension          sync.RWMutex
-	lockInstanceExists           sync.RWMutex
 }
 
 // AddDimensions calls AddDimensionsFunc.
@@ -195,9 +198,9 @@ func (mock *StorerMock) AddDimensions(ctx context.Context, instanceID string, di
 		InstanceID: instanceID,
 		Dimensions: dimensions,
 	}
-	mock.lockAddDimensions.Lock()
+	lockStorerMockAddDimensions.Lock()
 	mock.calls.AddDimensions = append(mock.calls.AddDimensions, callInfo)
-	mock.lockAddDimensions.Unlock()
+	lockStorerMockAddDimensions.Unlock()
 	return mock.AddDimensionsFunc(ctx, instanceID, dimensions)
 }
 
@@ -214,9 +217,9 @@ func (mock *StorerMock) AddDimensionsCalls() []struct {
 		InstanceID string
 		Dimensions []interface{}
 	}
-	mock.lockAddDimensions.RLock()
+	lockStorerMockAddDimensions.RLock()
 	calls = mock.calls.AddDimensions
-	mock.lockAddDimensions.RUnlock()
+	lockStorerMockAddDimensions.RUnlock()
 	return calls
 }
 
@@ -232,9 +235,9 @@ func (mock *StorerMock) Checker(ctx context.Context, state *healthcheck.CheckSta
 		Ctx:   ctx,
 		State: state,
 	}
-	mock.lockChecker.Lock()
+	lockStorerMockChecker.Lock()
 	mock.calls.Checker = append(mock.calls.Checker, callInfo)
-	mock.lockChecker.Unlock()
+	lockStorerMockChecker.Unlock()
 	return mock.CheckerFunc(ctx, state)
 }
 
@@ -249,9 +252,9 @@ func (mock *StorerMock) CheckerCalls() []struct {
 		Ctx   context.Context
 		State *healthcheck.CheckState
 	}
-	mock.lockChecker.RLock()
+	lockStorerMockChecker.RLock()
 	calls = mock.calls.Checker
-	mock.lockChecker.RUnlock()
+	lockStorerMockChecker.RUnlock()
 	return calls
 }
 
@@ -265,9 +268,9 @@ func (mock *StorerMock) Close(ctx context.Context) error {
 	}{
 		Ctx: ctx,
 	}
-	mock.lockClose.Lock()
+	lockStorerMockClose.Lock()
 	mock.calls.Close = append(mock.calls.Close, callInfo)
-	mock.lockClose.Unlock()
+	lockStorerMockClose.Unlock()
 	return mock.CloseFunc(ctx)
 }
 
@@ -280,9 +283,9 @@ func (mock *StorerMock) CloseCalls() []struct {
 	var calls []struct {
 		Ctx context.Context
 	}
-	mock.lockClose.RLock()
+	lockStorerMockClose.RLock()
 	calls = mock.calls.Close
-	mock.lockClose.RUnlock()
+	lockStorerMockClose.RUnlock()
 	return calls
 }
 
@@ -302,9 +305,9 @@ func (mock *StorerMock) CreateCodeRelationship(ctx context.Context, instanceID s
 		CodeListID: codeListID,
 		Code:       code,
 	}
-	mock.lockCreateCodeRelationship.Lock()
+	lockStorerMockCreateCodeRelationship.Lock()
 	mock.calls.CreateCodeRelationship = append(mock.calls.CreateCodeRelationship, callInfo)
-	mock.lockCreateCodeRelationship.Unlock()
+	lockStorerMockCreateCodeRelationship.Unlock()
 	return mock.CreateCodeRelationshipFunc(ctx, instanceID, codeListID, code)
 }
 
@@ -323,9 +326,9 @@ func (mock *StorerMock) CreateCodeRelationshipCalls() []struct {
 		CodeListID string
 		Code       string
 	}
-	mock.lockCreateCodeRelationship.RLock()
+	lockStorerMockCreateCodeRelationship.RLock()
 	calls = mock.calls.CreateCodeRelationship
-	mock.lockCreateCodeRelationship.RUnlock()
+	lockStorerMockCreateCodeRelationship.RUnlock()
 	return calls
 }
 
@@ -343,9 +346,9 @@ func (mock *StorerMock) CreateInstance(ctx context.Context, instanceID string, c
 		InstanceID: instanceID,
 		CsvHeaders: csvHeaders,
 	}
-	mock.lockCreateInstance.Lock()
+	lockStorerMockCreateInstance.Lock()
 	mock.calls.CreateInstance = append(mock.calls.CreateInstance, callInfo)
-	mock.lockCreateInstance.Unlock()
+	lockStorerMockCreateInstance.Unlock()
 	return mock.CreateInstanceFunc(ctx, instanceID, csvHeaders)
 }
 
@@ -362,9 +365,9 @@ func (mock *StorerMock) CreateInstanceCalls() []struct {
 		InstanceID string
 		CsvHeaders []string
 	}
-	mock.lockCreateInstance.RLock()
+	lockStorerMockCreateInstance.RLock()
 	calls = mock.calls.CreateInstance
-	mock.lockCreateInstance.RUnlock()
+	lockStorerMockCreateInstance.RUnlock()
 	return calls
 }
 
@@ -380,9 +383,9 @@ func (mock *StorerMock) CreateInstanceConstraint(ctx context.Context, instanceID
 		Ctx:        ctx,
 		InstanceID: instanceID,
 	}
-	mock.lockCreateInstanceConstraint.Lock()
+	lockStorerMockCreateInstanceConstraint.Lock()
 	mock.calls.CreateInstanceConstraint = append(mock.calls.CreateInstanceConstraint, callInfo)
-	mock.lockCreateInstanceConstraint.Unlock()
+	lockStorerMockCreateInstanceConstraint.Unlock()
 	return mock.CreateInstanceConstraintFunc(ctx, instanceID)
 }
 
@@ -397,9 +400,9 @@ func (mock *StorerMock) CreateInstanceConstraintCalls() []struct {
 		Ctx        context.Context
 		InstanceID string
 	}
-	mock.lockCreateInstanceConstraint.RLock()
+	lockStorerMockCreateInstanceConstraint.RLock()
 	calls = mock.calls.CreateInstanceConstraint
-	mock.lockCreateInstanceConstraint.RUnlock()
+	lockStorerMockCreateInstanceConstraint.RUnlock()
 	return calls
 }
 
@@ -410,9 +413,9 @@ func (mock *StorerMock) ErrorChan() chan error {
 	}
 	callInfo := struct {
 	}{}
-	mock.lockErrorChan.Lock()
+	lockStorerMockErrorChan.Lock()
 	mock.calls.ErrorChan = append(mock.calls.ErrorChan, callInfo)
-	mock.lockErrorChan.Unlock()
+	lockStorerMockErrorChan.Unlock()
 	return mock.ErrorChanFunc()
 }
 
@@ -423,9 +426,9 @@ func (mock *StorerMock) ErrorChanCalls() []struct {
 } {
 	var calls []struct {
 	}
-	mock.lockErrorChan.RLock()
+	lockStorerMockErrorChan.RLock()
 	calls = mock.calls.ErrorChan
-	mock.lockErrorChan.RUnlock()
+	lockStorerMockErrorChan.RUnlock()
 	return calls
 }
 
@@ -443,9 +446,9 @@ func (mock *StorerMock) GetCodesOrder(ctx context.Context, codeListID string, co
 		CodeListID: codeListID,
 		Codes:      codes,
 	}
-	mock.lockGetCodesOrder.Lock()
+	lockStorerMockGetCodesOrder.Lock()
 	mock.calls.GetCodesOrder = append(mock.calls.GetCodesOrder, callInfo)
-	mock.lockGetCodesOrder.Unlock()
+	lockStorerMockGetCodesOrder.Unlock()
 	return mock.GetCodesOrderFunc(ctx, codeListID, codes)
 }
 
@@ -462,9 +465,9 @@ func (mock *StorerMock) GetCodesOrderCalls() []struct {
 		CodeListID string
 		Codes      []string
 	}
-	mock.lockGetCodesOrder.RLock()
+	lockStorerMockGetCodesOrder.RLock()
 	calls = mock.calls.GetCodesOrder
-	mock.lockGetCodesOrder.RUnlock()
+	lockStorerMockGetCodesOrder.RUnlock()
 	return calls
 }
 
@@ -484,9 +487,9 @@ func (mock *StorerMock) InsertDimension(ctx context.Context, cache map[string]st
 		InstanceID: instanceID,
 		Dimension:  dimension,
 	}
-	mock.lockInsertDimension.Lock()
+	lockStorerMockInsertDimension.Lock()
 	mock.calls.InsertDimension = append(mock.calls.InsertDimension, callInfo)
-	mock.lockInsertDimension.Unlock()
+	lockStorerMockInsertDimension.Unlock()
 	return mock.InsertDimensionFunc(ctx, cache, instanceID, dimension)
 }
 
@@ -505,9 +508,9 @@ func (mock *StorerMock) InsertDimensionCalls() []struct {
 		InstanceID string
 		Dimension  *models.Dimension
 	}
-	mock.lockInsertDimension.RLock()
+	lockStorerMockInsertDimension.RLock()
 	calls = mock.calls.InsertDimension
-	mock.lockInsertDimension.RUnlock()
+	lockStorerMockInsertDimension.RUnlock()
 	return calls
 }
 
@@ -523,9 +526,9 @@ func (mock *StorerMock) InstanceExists(ctx context.Context, instanceID string) (
 		Ctx:        ctx,
 		InstanceID: instanceID,
 	}
-	mock.lockInstanceExists.Lock()
+	lockStorerMockInstanceExists.Lock()
 	mock.calls.InstanceExists = append(mock.calls.InstanceExists, callInfo)
-	mock.lockInstanceExists.Unlock()
+	lockStorerMockInstanceExists.Unlock()
 	return mock.InstanceExistsFunc(ctx, instanceID)
 }
 
@@ -540,8 +543,8 @@ func (mock *StorerMock) InstanceExistsCalls() []struct {
 		Ctx        context.Context
 		InstanceID string
 	}
-	mock.lockInstanceExists.RLock()
+	lockStorerMockInstanceExists.RLock()
 	calls = mock.calls.InstanceExists
-	mock.lockInstanceExists.RUnlock()
+	lockStorerMockInstanceExists.RUnlock()
 	return calls
 }


### PR DESCRIPTION
### What

- Update dp-api-clients-go to use the fix for `GetInstanceDimensions`
- Update signature and mocks to ignore userAuthToken
- Created config paramters for datset api pagination calls (batch size and max workers)

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

- (info, no need to reproduce) I tested it locally by running it along with dataset api and producing a message for an instance that exists in my local modgoDB. Added logs and validated that the expected instance dimensions are returned.

### Who can review

Anyone