### PR TITLE
Update to use dp-api-clients-go v.2.0.6-beta

### DIFF
--- a/client/dimensions_api.go
+++ b/client/dimensions_api.go
@@ -95,17 +95,17 @@ func (api DatasetAPI) GetDimensions(ctx context.Context, instanceID string, ifMa
 // PatchDimensionOption make a HTTP patch request to update the node_id and/or order of the specified dimension.
 func (api DatasetAPI) PatchDimensionOption(ctx context.Context, instanceID string, d *model.Dimension, order *int) (string, error) {
 	if len(instanceID) == 0 {
-		return headers.IfMatchAnyETag, ErrInstanceIDEmpty
+		return "", ErrInstanceIDEmpty
 	}
 	if d == nil {
-		return headers.IfMatchAnyETag, ErrDimensionNil
+		return "", ErrDimensionNil
 	}
 	dim := d.DbModel()
 	if dim == nil {
-		return headers.IfMatchAnyETag, ErrDimensionNil
+		return "", ErrDimensionNil
 	}
 	if len(dim.DimensionID) == 0 {
-		return headers.IfMatchAnyETag, ErrDimensionIDEmpty
+		return "", ErrDimensionIDEmpty
 	}
 
 	nodeID := ""

--- a/client/dimensions_api.go
+++ b/client/dimensions_api.go
@@ -6,7 +6,8 @@ import (
 
 	"net/url"
 
-	dataset "github.com/ONSdigital/dp-api-clients-go/dataset"
+	dataset "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 	"github.com/ONSdigital/dp-dimension-importer/config"
 	"github.com/ONSdigital/dp-dimension-importer/model"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -30,9 +31,9 @@ var ErrDimensionIDEmpty = errors.New("dimension.id is required but is empty")
 
 // IClient is an interface that represents the required functionality from dataset client from dp-api-clients-go
 type IClient interface {
-	PatchInstanceDimensionOption(ctx context.Context, serviceAuthToken, instanceID, dimensionID, optionID, nodeID string, order *int) error
-	GetInstanceDimensionsInBatches(ctx context.Context, serviceAuthToken, instanceID string, batchSize, maxWorkers int) (m dataset.Dimensions, err error)
-	GetInstance(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, instanceID string) (m dataset.Instance, err error)
+	PatchInstanceDimensionOption(ctx context.Context, serviceAuthToken, instanceID, dimensionID, optionID, nodeID string, order *int, ifMatch string) (eTag string, err error)
+	GetInstanceDimensionsInBatches(ctx context.Context, serviceAuthToken, instanceID string, batchSize, maxWorkers int) (dimensions dataset.Dimensions, eTag string, err error)
+	GetInstance(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, instanceID, ifMatch string) (m dataset.Instance, eTag string, err error)
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
 }
 
@@ -66,7 +67,7 @@ func (api DatasetAPI) GetInstance(ctx context.Context, instanceID string) (*mode
 	if len(instanceID) == 0 {
 		return &model.Instance{}, ErrInstanceIDEmpty
 	}
-	datasetInstance, err := api.Client.GetInstance(ctx, "", api.AuthToken, "", instanceID)
+	datasetInstance, _, err := api.Client.GetInstance(ctx, "", api.AuthToken, "", instanceID, headers.IfMatchAnyETag)
 	if err != nil {
 		return nil, err
 	}
@@ -74,12 +75,12 @@ func (api DatasetAPI) GetInstance(ctx context.Context, instanceID string) (*mode
 }
 
 // GetDimensions retrieve the dimensions of the specified instance from the Dataset API
-func (api DatasetAPI) GetDimensions(ctx context.Context, instanceID string) ([]*model.Dimension, error) {
+func (api DatasetAPI) GetDimensions(ctx context.Context, instanceID string, ifMatch string) ([]*model.Dimension, error) {
 	if len(instanceID) == 0 {
 		return nil, ErrInstanceIDEmpty
 	}
 
-	dimensions, err := api.Client.GetInstanceDimensionsInBatches(ctx, api.AuthToken, instanceID, api.BatchSize, api.MaxWorkers)
+	dimensions, _, err := api.Client.GetInstanceDimensionsInBatches(ctx, api.AuthToken, instanceID, api.BatchSize, api.MaxWorkers)
 	if err != nil {
 		return nil, err
 	}
@@ -92,19 +93,19 @@ func (api DatasetAPI) GetDimensions(ctx context.Context, instanceID string) ([]*
 }
 
 // PatchDimensionOption make a HTTP patch request to update the node_id and/or order of the specified dimension.
-func (api DatasetAPI) PatchDimensionOption(ctx context.Context, instanceID string, d *model.Dimension, order *int) error {
+func (api DatasetAPI) PatchDimensionOption(ctx context.Context, instanceID string, d *model.Dimension, order *int) (string, error) {
 	if len(instanceID) == 0 {
-		return ErrInstanceIDEmpty
+		return headers.IfMatchAnyETag, ErrInstanceIDEmpty
 	}
 	if d == nil {
-		return ErrDimensionNil
+		return headers.IfMatchAnyETag, ErrDimensionNil
 	}
 	dim := d.DbModel()
 	if dim == nil {
-		return ErrDimensionNil
+		return headers.IfMatchAnyETag, ErrDimensionNil
 	}
 	if len(dim.DimensionID) == 0 {
-		return ErrDimensionIDEmpty
+		return headers.IfMatchAnyETag, ErrDimensionIDEmpty
 	}
 
 	nodeID := ""
@@ -112,5 +113,5 @@ func (api DatasetAPI) PatchDimensionOption(ctx context.Context, instanceID strin
 		nodeID = dim.NodeID
 	}
 
-	return api.Client.PatchInstanceDimensionOption(ctx, api.AuthToken, instanceID, dim.DimensionID, url.PathEscape(dim.Option), nodeID, order)
+	return api.Client.PatchInstanceDimensionOption(ctx, api.AuthToken, instanceID, dim.DimensionID, url.PathEscape(dim.Option), nodeID, order, headers.IfMatchAnyETag)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-dimension-importer
 go 1.16
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.36.1
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta
 	github.com/ONSdigital/dp-graph/v2 v2.13.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-kafka/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
+github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
+github.com/ONSdigital/dp-api-clients-go v1.36.0 h1:bAxGiC2rgmtvLTa5YAKJw6OyO9kZSSCDbvwUDg5r5Oc=
 github.com/ONSdigital/dp-api-clients-go v1.36.0/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
-github.com/ONSdigital/dp-api-clients-go v1.36.1 h1:fI4NuoE+DHYyloNEhPsXQDFoJMwftgj7GVt+H3BGwFE=
-github.com/ONSdigital/dp-api-clients-go v1.36.1/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta h1:Wbjibp0/LLoRewWQfmbWw26iKDixw+iiA42OQgRqTQ4=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta/go.mod h1:zN8+84r1tWgyCmypku7JFN63nCMOGTIM26zf5GwHkJ4=
 github.com/ONSdigital/dp-graph/v2 v2.13.1 h1:txp2WOtmA/S3g4BzcZ2uxcSvp0nBUtZTzWjkbDrSHqs=
 github.com/ONSdigital/dp-graph/v2 v2.13.1/go.mod h1:goNf7IF+hJATF9F8DD8QAHNF38s/0wRMzgHxzOamDKo=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
@@ -32,6 +34,7 @@ github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQ
 github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9MYC+cV9VfjRD0UBGj8PA7H3wABqQi87/ejrDhYc=
 github.com/ONSdigital/log.go v1.0.1 h1:SZ5wRZAwlt2jQUZ9AUzBB/PL+iG15KapfQpJUdA18/4=
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
+github.com/ONSdigital/log.go/v2 v2.0.0/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
 github.com/Shopify/sarama v1.27.0/go.mod h1:aCdj6ymI8uyPEux1JJ9gcaDT6cinjGhNCAhs54taSUo=
 github.com/Shopify/sarama v1.27.2 h1:1EyY1dsxNDUQEv0O/4TsjosHI2CgB1uo9H/v56xzTxc=
 github.com/Shopify/sarama v1.27.2/go.mod h1:g5s5osgELxgM+Md9Qni9rzo7Rbt+vvFQI4bt/Mc93II=
@@ -49,6 +52,7 @@ github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmAp6Sws4L7+Q/OokbWDAK1ibXYhB3PXFP1kol5hPg=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
@@ -107,6 +111,7 @@ github.com/mattn/go-isatty v0.0.13 h1:qdl+GuBjcsKKDco5BsxPJlId98mSWNKqYA+Co0SC1y
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUMhxq9m9ZXI=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -155,6 +160,7 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644 h1:CA1DEQ4NdKphKeL70tvsWNdT5oFh1lOjihRcEDROi0I=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -171,6 +177,7 @@ gopkg.in/avro.v0 v0.0.0-20171217001914-a730b5802183 h1:PGIdqvwfpMUyUP+QAlAnKTSWQ
 gopkg.in/avro.v0 v0.0.0-20171217001914-a730b5802183/go.mod h1:FvqrFXt+jCsyQibeRv4xxEJBL5iG2DDW5aeJwzDiq4A=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/jcmturner/aescts.v1 v1.0.1 h1:cVVZBK2b1zY26haWB4vbBiZrfFQnfbTVrE3xZq6hrEw=
 gopkg.in/jcmturner/aescts.v1 v1.0.1/go.mod h1:nsR8qBOg+OucoIW+WMhB3GspUQXq9XorLnQb9XtvcOo=

--- a/handler/incoming_instance_handler.go
+++ b/handler/incoming_instance_handler.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 	"github.com/ONSdigital/dp-dimension-importer/client"
 	"github.com/ONSdigital/dp-dimension-importer/event"
 	"github.com/ONSdigital/dp-dimension-importer/model"
@@ -50,7 +51,7 @@ func (hdlr *InstanceEventHandler) Handle(ctx context.Context, newInstance event.
 
 	start := time.Now()
 
-	dimensions, err := hdlr.DatasetAPICli.GetDimensions(ctx, newInstance.InstanceID)
+	dimensions, err := hdlr.DatasetAPICli.GetDimensions(ctx, newInstance.InstanceID, headers.IfMatchAnyETag)
 	if err != nil {
 		return fmt.Errorf("DatasetAPICli.GetDimensions returned an error: %w", err)
 	}
@@ -188,7 +189,7 @@ func (hdlr *InstanceEventHandler) insertDimension(ctx context.Context, cache map
 		return
 	}
 
-	if err = hdlr.DatasetAPICli.PatchDimensionOption(ctx, instance.DbModel().InstanceID, d, order); err != nil {
+	if _, err = hdlr.DatasetAPICli.PatchDimensionOption(ctx, instance.DbModel().InstanceID, d, order); err != nil {
 		err = fmt.Errorf("DatasetAPICli.PatchDimensionOption returned an error: %w", err)
 		log.Event(ctx, err.Error(), log.Error(err), log.Data{"instance_id": instance.DbModel().InstanceID, "dimension_id": dbDimension.DimensionID})
 		problem <- err

--- a/handler/incoming_instance_handler_test.go
+++ b/handler/incoming_instance_handler_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ONSdigital/dp-api-clients-go/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-dimension-importer/client"
 	"github.com/ONSdigital/dp-dimension-importer/event"
 	"github.com/ONSdigital/dp-dimension-importer/handler"
@@ -177,8 +177,8 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		Convey("When DatasetAPICli.GetInstanceDimensions returns an error", func() {
 			event := event.NewInstance{InstanceID: testInstanceID}
 
-			datasetAPIMock.GetInstanceDimensionsInBatchesFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, maxWorkers, batchSize int) (dataset.Dimensions, error) {
-				return dataset.Dimensions{}, errorMock
+			datasetAPIMock.GetInstanceDimensionsInBatchesFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, maxWorkers, batchSize int) (dataset.Dimensions, string, error) {
+				return dataset.Dimensions{}, "", errorMock
 			}
 
 			err := handler.Handle(ctx, event)
@@ -394,8 +394,8 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 			storerMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
 				return dimension, nil
 			}
-			datasetAPIMock.PatchInstanceDimensionOptionFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, dimensionID string, optionID string, nodeID string, order *int) error {
-				return errorMock
+			datasetAPIMock.PatchInstanceDimensionOptionFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, dimensionID string, optionID string, nodeID string, order *int, ifMatch string) (string, error) {
+				return "", errorMock
 			}
 
 			err := handler.Handle(ctx, event)
@@ -455,8 +455,8 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 			storerMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
 				return dimension, nil
 			}
-			datasetAPIMock.PatchInstanceDimensionOptionFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, dimensionID string, optionID string, nodeID string, order *int) error {
-				return nil
+			datasetAPIMock.PatchInstanceDimensionOptionFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, dimensionID string, optionID string, nodeID string, order *int, ifMatch string) (string, error) {
+				return "", nil
 			}
 			storerMock.AddDimensionsFunc = func(ctx context.Context, instanceID string, dimensions []interface{}) error {
 				return errorMock
@@ -694,14 +694,14 @@ func setUp() (*storertest.StorerMock, *mocks.IClientMock, *mocks.CompletedProduc
 	}
 
 	datasetAPIMock := &mocks.IClientMock{
-		GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, maxWorkers, batchSize int) (dataset.Dimensions, error) {
-			return dataset.Dimensions{Items: []dataset.Dimension{d1Api, d2Api}}, nil
+		GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, maxWorkers, batchSize int) (dataset.Dimensions, string, error) {
+			return dataset.Dimensions{Items: []dataset.Dimension{d1Api, d2Api}}, "", nil
 		},
-		PatchInstanceDimensionOptionFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, dimensionID string, optionID string, nodeID string, order *int) error {
-			return nil
+		PatchInstanceDimensionOptionFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, dimensionID string, optionID string, nodeID string, order *int, ifMatch string) (string, error) {
+			return "", nil
 		},
-		GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string) (dataset.Instance, error) {
-			return instanceApi, nil
+		GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
+			return instanceApi, "", nil
 		},
 	}
 	datasetAPIClient := &client.DatasetAPI{

--- a/message/mock/instance_event_handler.go
+++ b/message/mock/instance_event_handler.go
@@ -10,29 +10,25 @@ import (
 	"sync"
 )
 
-var (
-	lockInstanceEventHandlerMockHandle sync.RWMutex
-)
-
 // Ensure, that InstanceEventHandlerMock does implement message.InstanceEventHandler.
 // If this is not the case, regenerate this file with moq.
 var _ message.InstanceEventHandler = &InstanceEventHandlerMock{}
 
 // InstanceEventHandlerMock is a mock implementation of message.InstanceEventHandler.
 //
-//     func TestSomethingThatUsesInstanceEventHandler(t *testing.T) {
+// 	func TestSomethingThatUsesInstanceEventHandler(t *testing.T) {
 //
-//         // make and configure a mocked message.InstanceEventHandler
-//         mockedInstanceEventHandler := &InstanceEventHandlerMock{
-//             HandleFunc: func(ctx context.Context, e event.NewInstance) error {
-// 	               panic("mock out the Handle method")
-//             },
-//         }
+// 		// make and configure a mocked message.InstanceEventHandler
+// 		mockedInstanceEventHandler := &InstanceEventHandlerMock{
+// 			HandleFunc: func(ctx context.Context, e event.NewInstance) error {
+// 				panic("mock out the Handle method")
+// 			},
+// 		}
 //
-//         // use mockedInstanceEventHandler in code that requires message.InstanceEventHandler
-//         // and then make assertions.
+// 		// use mockedInstanceEventHandler in code that requires message.InstanceEventHandler
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type InstanceEventHandlerMock struct {
 	// HandleFunc mocks the Handle method.
 	HandleFunc func(ctx context.Context, e event.NewInstance) error
@@ -47,6 +43,7 @@ type InstanceEventHandlerMock struct {
 			E event.NewInstance
 		}
 	}
+	lockHandle sync.RWMutex
 }
 
 // Handle calls HandleFunc.
@@ -61,9 +58,9 @@ func (mock *InstanceEventHandlerMock) Handle(ctx context.Context, e event.NewIns
 		Ctx: ctx,
 		E:   e,
 	}
-	lockInstanceEventHandlerMockHandle.Lock()
+	mock.lockHandle.Lock()
 	mock.calls.Handle = append(mock.calls.Handle, callInfo)
-	lockInstanceEventHandlerMockHandle.Unlock()
+	mock.lockHandle.Unlock()
 	return mock.HandleFunc(ctx, e)
 }
 
@@ -78,8 +75,8 @@ func (mock *InstanceEventHandlerMock) HandleCalls() []struct {
 		Ctx context.Context
 		E   event.NewInstance
 	}
-	lockInstanceEventHandlerMockHandle.RLock()
+	mock.lockHandle.RLock()
 	calls = mock.calls.Handle
-	lockInstanceEventHandlerMockHandle.RUnlock()
+	mock.lockHandle.RUnlock()
 	return calls
 }

--- a/message/mock/producer.go
+++ b/message/mock/producer.go
@@ -8,29 +8,25 @@ import (
 	"sync"
 )
 
-var (
-	lockMarshallerMockMarshal sync.RWMutex
-)
-
 // Ensure, that MarshallerMock does implement message.Marshaller.
 // If this is not the case, regenerate this file with moq.
 var _ message.Marshaller = &MarshallerMock{}
 
 // MarshallerMock is a mock implementation of message.Marshaller.
 //
-//     func TestSomethingThatUsesMarshaller(t *testing.T) {
+// 	func TestSomethingThatUsesMarshaller(t *testing.T) {
 //
-//         // make and configure a mocked message.Marshaller
-//         mockedMarshaller := &MarshallerMock{
-//             MarshalFunc: func(s interface{}) ([]byte, error) {
-// 	               panic("mock out the Marshal method")
-//             },
-//         }
+// 		// make and configure a mocked message.Marshaller
+// 		mockedMarshaller := &MarshallerMock{
+// 			MarshalFunc: func(s interface{}) ([]byte, error) {
+// 				panic("mock out the Marshal method")
+// 			},
+// 		}
 //
-//         // use mockedMarshaller in code that requires message.Marshaller
-//         // and then make assertions.
+// 		// use mockedMarshaller in code that requires message.Marshaller
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type MarshallerMock struct {
 	// MarshalFunc mocks the Marshal method.
 	MarshalFunc func(s interface{}) ([]byte, error)
@@ -43,6 +39,7 @@ type MarshallerMock struct {
 			S interface{}
 		}
 	}
+	lockMarshal sync.RWMutex
 }
 
 // Marshal calls MarshalFunc.
@@ -55,9 +52,9 @@ func (mock *MarshallerMock) Marshal(s interface{}) ([]byte, error) {
 	}{
 		S: s,
 	}
-	lockMarshallerMockMarshal.Lock()
+	mock.lockMarshal.Lock()
 	mock.calls.Marshal = append(mock.calls.Marshal, callInfo)
-	lockMarshallerMockMarshal.Unlock()
+	mock.lockMarshal.Unlock()
 	return mock.MarshalFunc(s)
 }
 
@@ -70,8 +67,8 @@ func (mock *MarshallerMock) MarshalCalls() []struct {
 	var calls []struct {
 		S interface{}
 	}
-	lockMarshallerMockMarshal.RLock()
+	mock.lockMarshal.RLock()
 	calls = mock.calls.Marshal
-	lockMarshallerMockMarshal.RUnlock()
+	mock.lockMarshal.RUnlock()
 	return calls
 }

--- a/message/mock/receiver.go
+++ b/message/mock/receiver.go
@@ -5,12 +5,8 @@ package mock
 
 import (
 	"github.com/ONSdigital/dp-dimension-importer/message"
-	"github.com/ONSdigital/dp-kafka/v2"
+	kafka "github.com/ONSdigital/dp-kafka/v2"
 	"sync"
-)
-
-var (
-	lockReceiverMockOnMessage sync.RWMutex
 )
 
 // Ensure, that ReceiverMock does implement message.Receiver.
@@ -19,19 +15,19 @@ var _ message.Receiver = &ReceiverMock{}
 
 // ReceiverMock is a mock implementation of message.Receiver.
 //
-//     func TestSomethingThatUsesReceiver(t *testing.T) {
+// 	func TestSomethingThatUsesReceiver(t *testing.T) {
 //
-//         // make and configure a mocked message.Receiver
-//         mockedReceiver := &ReceiverMock{
-//             OnMessageFunc: func(message kafka.Message)  {
-// 	               panic("mock out the OnMessage method")
-//             },
-//         }
+// 		// make and configure a mocked message.Receiver
+// 		mockedReceiver := &ReceiverMock{
+// 			OnMessageFunc: func(message kafka.Message)  {
+// 				panic("mock out the OnMessage method")
+// 			},
+// 		}
 //
-//         // use mockedReceiver in code that requires message.Receiver
-//         // and then make assertions.
+// 		// use mockedReceiver in code that requires message.Receiver
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type ReceiverMock struct {
 	// OnMessageFunc mocks the OnMessage method.
 	OnMessageFunc func(message kafka.Message)
@@ -44,6 +40,7 @@ type ReceiverMock struct {
 			Message kafka.Message
 		}
 	}
+	lockOnMessage sync.RWMutex
 }
 
 // OnMessage calls OnMessageFunc.
@@ -56,9 +53,9 @@ func (mock *ReceiverMock) OnMessage(message kafka.Message) {
 	}{
 		Message: message,
 	}
-	lockReceiverMockOnMessage.Lock()
+	mock.lockOnMessage.Lock()
 	mock.calls.OnMessage = append(mock.calls.OnMessage, callInfo)
-	lockReceiverMockOnMessage.Unlock()
+	mock.lockOnMessage.Unlock()
 	mock.OnMessageFunc(message)
 }
 
@@ -71,8 +68,8 @@ func (mock *ReceiverMock) OnMessageCalls() []struct {
 	var calls []struct {
 		Message kafka.Message
 	}
-	lockReceiverMockOnMessage.RLock()
+	mock.lockOnMessage.RLock()
 	calls = mock.calls.OnMessage
-	lockReceiverMockOnMessage.RUnlock()
+	mock.lockOnMessage.RUnlock()
 	return calls
 }

--- a/mocks/incoming_instance_generated_mocks.go
+++ b/mocks/incoming_instance_generated_mocks.go
@@ -10,29 +10,25 @@ import (
 	"sync"
 )
 
-var (
-	lockCompletedProducerMockCompleted sync.RWMutex
-)
-
 // Ensure, that CompletedProducerMock does implement handler.CompletedProducer.
 // If this is not the case, regenerate this file with moq.
 var _ handler.CompletedProducer = &CompletedProducerMock{}
 
 // CompletedProducerMock is a mock implementation of handler.CompletedProducer.
 //
-//     func TestSomethingThatUsesCompletedProducer(t *testing.T) {
+// 	func TestSomethingThatUsesCompletedProducer(t *testing.T) {
 //
-//         // make and configure a mocked handler.CompletedProducer
-//         mockedCompletedProducer := &CompletedProducerMock{
-//             CompletedFunc: func(ctx context.Context, e event.InstanceCompleted) error {
-// 	               panic("mock out the Completed method")
-//             },
-//         }
+// 		// make and configure a mocked handler.CompletedProducer
+// 		mockedCompletedProducer := &CompletedProducerMock{
+// 			CompletedFunc: func(ctx context.Context, e event.InstanceCompleted) error {
+// 				panic("mock out the Completed method")
+// 			},
+// 		}
 //
-//         // use mockedCompletedProducer in code that requires handler.CompletedProducer
-//         // and then make assertions.
+// 		// use mockedCompletedProducer in code that requires handler.CompletedProducer
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type CompletedProducerMock struct {
 	// CompletedFunc mocks the Completed method.
 	CompletedFunc func(ctx context.Context, e event.InstanceCompleted) error
@@ -47,6 +43,7 @@ type CompletedProducerMock struct {
 			E event.InstanceCompleted
 		}
 	}
+	lockCompleted sync.RWMutex
 }
 
 // Completed calls CompletedFunc.
@@ -61,9 +58,9 @@ func (mock *CompletedProducerMock) Completed(ctx context.Context, e event.Instan
 		Ctx: ctx,
 		E:   e,
 	}
-	lockCompletedProducerMockCompleted.Lock()
+	mock.lockCompleted.Lock()
 	mock.calls.Completed = append(mock.calls.Completed, callInfo)
-	lockCompletedProducerMockCompleted.Unlock()
+	mock.lockCompleted.Unlock()
 	return mock.CompletedFunc(ctx, e)
 }
 
@@ -78,8 +75,8 @@ func (mock *CompletedProducerMock) CompletedCalls() []struct {
 		Ctx context.Context
 		E   event.InstanceCompleted
 	}
-	lockCompletedProducerMockCompleted.RLock()
+	mock.lockCompleted.RLock()
 	calls = mock.calls.Completed
-	lockCompletedProducerMockCompleted.RUnlock()
+	mock.lockCompleted.RUnlock()
 	return calls
 }

--- a/model/models.go
+++ b/model/models.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	dataset "github.com/ONSdigital/dp-api-clients-go/dataset"
+	dataset "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	db "github.com/ONSdigital/dp-graph/v2/models"
 )
 

--- a/model/models_test.go
+++ b/model/models_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	dataset "github.com/ONSdigital/dp-api-clients-go/dataset"
+	dataset "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	db "github.com/ONSdigital/dp-graph/v2/models"
 
 	. "github.com/smartystreets/goconvey/convey"

--- a/store/storertest/storer.go
+++ b/store/storertest/storer.go
@@ -11,65 +11,52 @@ import (
 	"sync"
 )
 
-var (
-	lockStorerMockAddDimensions            sync.RWMutex
-	lockStorerMockChecker                  sync.RWMutex
-	lockStorerMockClose                    sync.RWMutex
-	lockStorerMockCreateCodeRelationship   sync.RWMutex
-	lockStorerMockCreateInstance           sync.RWMutex
-	lockStorerMockCreateInstanceConstraint sync.RWMutex
-	lockStorerMockErrorChan                sync.RWMutex
-	lockStorerMockGetCodesOrder            sync.RWMutex
-	lockStorerMockInsertDimension          sync.RWMutex
-	lockStorerMockInstanceExists           sync.RWMutex
-)
-
 // Ensure, that StorerMock does implement store.Storer.
 // If this is not the case, regenerate this file with moq.
 var _ store.Storer = &StorerMock{}
 
 // StorerMock is a mock implementation of store.Storer.
 //
-//     func TestSomethingThatUsesStorer(t *testing.T) {
+// 	func TestSomethingThatUsesStorer(t *testing.T) {
 //
-//         // make and configure a mocked store.Storer
-//         mockedStorer := &StorerMock{
-//             AddDimensionsFunc: func(ctx context.Context, instanceID string, dimensions []interface{}) error {
-// 	               panic("mock out the AddDimensions method")
-//             },
-//             CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
-// 	               panic("mock out the Checker method")
-//             },
-//             CloseFunc: func(ctx context.Context) error {
-// 	               panic("mock out the Close method")
-//             },
-//             CreateCodeRelationshipFunc: func(ctx context.Context, instanceID string, codeListID string, code string) error {
-// 	               panic("mock out the CreateCodeRelationship method")
-//             },
-//             CreateInstanceFunc: func(ctx context.Context, instanceID string, csvHeaders []string) error {
-// 	               panic("mock out the CreateInstance method")
-//             },
-//             CreateInstanceConstraintFunc: func(ctx context.Context, instanceID string) error {
-// 	               panic("mock out the CreateInstanceConstraint method")
-//             },
-//             ErrorChanFunc: func() chan error {
-// 	               panic("mock out the ErrorChan method")
-//             },
-//             GetCodesOrderFunc: func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
-// 	               panic("mock out the GetCodesOrder method")
-//             },
-//             InsertDimensionFunc: func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
-// 	               panic("mock out the InsertDimension method")
-//             },
-//             InstanceExistsFunc: func(ctx context.Context, instanceID string) (bool, error) {
-// 	               panic("mock out the InstanceExists method")
-//             },
-//         }
+// 		// make and configure a mocked store.Storer
+// 		mockedStorer := &StorerMock{
+// 			AddDimensionsFunc: func(ctx context.Context, instanceID string, dimensions []interface{}) error {
+// 				panic("mock out the AddDimensions method")
+// 			},
+// 			CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
+// 				panic("mock out the Checker method")
+// 			},
+// 			CloseFunc: func(ctx context.Context) error {
+// 				panic("mock out the Close method")
+// 			},
+// 			CreateCodeRelationshipFunc: func(ctx context.Context, instanceID string, codeListID string, code string) error {
+// 				panic("mock out the CreateCodeRelationship method")
+// 			},
+// 			CreateInstanceFunc: func(ctx context.Context, instanceID string, csvHeaders []string) error {
+// 				panic("mock out the CreateInstance method")
+// 			},
+// 			CreateInstanceConstraintFunc: func(ctx context.Context, instanceID string) error {
+// 				panic("mock out the CreateInstanceConstraint method")
+// 			},
+// 			ErrorChanFunc: func() chan error {
+// 				panic("mock out the ErrorChan method")
+// 			},
+// 			GetCodesOrderFunc: func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
+// 				panic("mock out the GetCodesOrder method")
+// 			},
+// 			InsertDimensionFunc: func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
+// 				panic("mock out the InsertDimension method")
+// 			},
+// 			InstanceExistsFunc: func(ctx context.Context, instanceID string) (bool, error) {
+// 				panic("mock out the InstanceExists method")
+// 			},
+// 		}
 //
-//         // use mockedStorer in code that requires store.Storer
-//         // and then make assertions.
+// 		// use mockedStorer in code that requires store.Storer
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type StorerMock struct {
 	// AddDimensionsFunc mocks the AddDimensions method.
 	AddDimensionsFunc func(ctx context.Context, instanceID string, dimensions []interface{}) error
@@ -182,6 +169,16 @@ type StorerMock struct {
 			InstanceID string
 		}
 	}
+	lockAddDimensions            sync.RWMutex
+	lockChecker                  sync.RWMutex
+	lockClose                    sync.RWMutex
+	lockCreateCodeRelationship   sync.RWMutex
+	lockCreateInstance           sync.RWMutex
+	lockCreateInstanceConstraint sync.RWMutex
+	lockErrorChan                sync.RWMutex
+	lockGetCodesOrder            sync.RWMutex
+	lockInsertDimension          sync.RWMutex
+	lockInstanceExists           sync.RWMutex
 }
 
 // AddDimensions calls AddDimensionsFunc.
@@ -198,9 +195,9 @@ func (mock *StorerMock) AddDimensions(ctx context.Context, instanceID string, di
 		InstanceID: instanceID,
 		Dimensions: dimensions,
 	}
-	lockStorerMockAddDimensions.Lock()
+	mock.lockAddDimensions.Lock()
 	mock.calls.AddDimensions = append(mock.calls.AddDimensions, callInfo)
-	lockStorerMockAddDimensions.Unlock()
+	mock.lockAddDimensions.Unlock()
 	return mock.AddDimensionsFunc(ctx, instanceID, dimensions)
 }
 
@@ -217,9 +214,9 @@ func (mock *StorerMock) AddDimensionsCalls() []struct {
 		InstanceID string
 		Dimensions []interface{}
 	}
-	lockStorerMockAddDimensions.RLock()
+	mock.lockAddDimensions.RLock()
 	calls = mock.calls.AddDimensions
-	lockStorerMockAddDimensions.RUnlock()
+	mock.lockAddDimensions.RUnlock()
 	return calls
 }
 
@@ -235,9 +232,9 @@ func (mock *StorerMock) Checker(ctx context.Context, state *healthcheck.CheckSta
 		Ctx:   ctx,
 		State: state,
 	}
-	lockStorerMockChecker.Lock()
+	mock.lockChecker.Lock()
 	mock.calls.Checker = append(mock.calls.Checker, callInfo)
-	lockStorerMockChecker.Unlock()
+	mock.lockChecker.Unlock()
 	return mock.CheckerFunc(ctx, state)
 }
 
@@ -252,9 +249,9 @@ func (mock *StorerMock) CheckerCalls() []struct {
 		Ctx   context.Context
 		State *healthcheck.CheckState
 	}
-	lockStorerMockChecker.RLock()
+	mock.lockChecker.RLock()
 	calls = mock.calls.Checker
-	lockStorerMockChecker.RUnlock()
+	mock.lockChecker.RUnlock()
 	return calls
 }
 
@@ -268,9 +265,9 @@ func (mock *StorerMock) Close(ctx context.Context) error {
 	}{
 		Ctx: ctx,
 	}
-	lockStorerMockClose.Lock()
+	mock.lockClose.Lock()
 	mock.calls.Close = append(mock.calls.Close, callInfo)
-	lockStorerMockClose.Unlock()
+	mock.lockClose.Unlock()
 	return mock.CloseFunc(ctx)
 }
 
@@ -283,9 +280,9 @@ func (mock *StorerMock) CloseCalls() []struct {
 	var calls []struct {
 		Ctx context.Context
 	}
-	lockStorerMockClose.RLock()
+	mock.lockClose.RLock()
 	calls = mock.calls.Close
-	lockStorerMockClose.RUnlock()
+	mock.lockClose.RUnlock()
 	return calls
 }
 
@@ -305,9 +302,9 @@ func (mock *StorerMock) CreateCodeRelationship(ctx context.Context, instanceID s
 		CodeListID: codeListID,
 		Code:       code,
 	}
-	lockStorerMockCreateCodeRelationship.Lock()
+	mock.lockCreateCodeRelationship.Lock()
 	mock.calls.CreateCodeRelationship = append(mock.calls.CreateCodeRelationship, callInfo)
-	lockStorerMockCreateCodeRelationship.Unlock()
+	mock.lockCreateCodeRelationship.Unlock()
 	return mock.CreateCodeRelationshipFunc(ctx, instanceID, codeListID, code)
 }
 
@@ -326,9 +323,9 @@ func (mock *StorerMock) CreateCodeRelationshipCalls() []struct {
 		CodeListID string
 		Code       string
 	}
-	lockStorerMockCreateCodeRelationship.RLock()
+	mock.lockCreateCodeRelationship.RLock()
 	calls = mock.calls.CreateCodeRelationship
-	lockStorerMockCreateCodeRelationship.RUnlock()
+	mock.lockCreateCodeRelationship.RUnlock()
 	return calls
 }
 
@@ -346,9 +343,9 @@ func (mock *StorerMock) CreateInstance(ctx context.Context, instanceID string, c
 		InstanceID: instanceID,
 		CsvHeaders: csvHeaders,
 	}
-	lockStorerMockCreateInstance.Lock()
+	mock.lockCreateInstance.Lock()
 	mock.calls.CreateInstance = append(mock.calls.CreateInstance, callInfo)
-	lockStorerMockCreateInstance.Unlock()
+	mock.lockCreateInstance.Unlock()
 	return mock.CreateInstanceFunc(ctx, instanceID, csvHeaders)
 }
 
@@ -365,9 +362,9 @@ func (mock *StorerMock) CreateInstanceCalls() []struct {
 		InstanceID string
 		CsvHeaders []string
 	}
-	lockStorerMockCreateInstance.RLock()
+	mock.lockCreateInstance.RLock()
 	calls = mock.calls.CreateInstance
-	lockStorerMockCreateInstance.RUnlock()
+	mock.lockCreateInstance.RUnlock()
 	return calls
 }
 
@@ -383,9 +380,9 @@ func (mock *StorerMock) CreateInstanceConstraint(ctx context.Context, instanceID
 		Ctx:        ctx,
 		InstanceID: instanceID,
 	}
-	lockStorerMockCreateInstanceConstraint.Lock()
+	mock.lockCreateInstanceConstraint.Lock()
 	mock.calls.CreateInstanceConstraint = append(mock.calls.CreateInstanceConstraint, callInfo)
-	lockStorerMockCreateInstanceConstraint.Unlock()
+	mock.lockCreateInstanceConstraint.Unlock()
 	return mock.CreateInstanceConstraintFunc(ctx, instanceID)
 }
 
@@ -400,9 +397,9 @@ func (mock *StorerMock) CreateInstanceConstraintCalls() []struct {
 		Ctx        context.Context
 		InstanceID string
 	}
-	lockStorerMockCreateInstanceConstraint.RLock()
+	mock.lockCreateInstanceConstraint.RLock()
 	calls = mock.calls.CreateInstanceConstraint
-	lockStorerMockCreateInstanceConstraint.RUnlock()
+	mock.lockCreateInstanceConstraint.RUnlock()
 	return calls
 }
 
@@ -413,9 +410,9 @@ func (mock *StorerMock) ErrorChan() chan error {
 	}
 	callInfo := struct {
 	}{}
-	lockStorerMockErrorChan.Lock()
+	mock.lockErrorChan.Lock()
 	mock.calls.ErrorChan = append(mock.calls.ErrorChan, callInfo)
-	lockStorerMockErrorChan.Unlock()
+	mock.lockErrorChan.Unlock()
 	return mock.ErrorChanFunc()
 }
 
@@ -426,9 +423,9 @@ func (mock *StorerMock) ErrorChanCalls() []struct {
 } {
 	var calls []struct {
 	}
-	lockStorerMockErrorChan.RLock()
+	mock.lockErrorChan.RLock()
 	calls = mock.calls.ErrorChan
-	lockStorerMockErrorChan.RUnlock()
+	mock.lockErrorChan.RUnlock()
 	return calls
 }
 
@@ -446,9 +443,9 @@ func (mock *StorerMock) GetCodesOrder(ctx context.Context, codeListID string, co
 		CodeListID: codeListID,
 		Codes:      codes,
 	}
-	lockStorerMockGetCodesOrder.Lock()
+	mock.lockGetCodesOrder.Lock()
 	mock.calls.GetCodesOrder = append(mock.calls.GetCodesOrder, callInfo)
-	lockStorerMockGetCodesOrder.Unlock()
+	mock.lockGetCodesOrder.Unlock()
 	return mock.GetCodesOrderFunc(ctx, codeListID, codes)
 }
 
@@ -465,9 +462,9 @@ func (mock *StorerMock) GetCodesOrderCalls() []struct {
 		CodeListID string
 		Codes      []string
 	}
-	lockStorerMockGetCodesOrder.RLock()
+	mock.lockGetCodesOrder.RLock()
 	calls = mock.calls.GetCodesOrder
-	lockStorerMockGetCodesOrder.RUnlock()
+	mock.lockGetCodesOrder.RUnlock()
 	return calls
 }
 
@@ -487,9 +484,9 @@ func (mock *StorerMock) InsertDimension(ctx context.Context, cache map[string]st
 		InstanceID: instanceID,
 		Dimension:  dimension,
 	}
-	lockStorerMockInsertDimension.Lock()
+	mock.lockInsertDimension.Lock()
 	mock.calls.InsertDimension = append(mock.calls.InsertDimension, callInfo)
-	lockStorerMockInsertDimension.Unlock()
+	mock.lockInsertDimension.Unlock()
 	return mock.InsertDimensionFunc(ctx, cache, instanceID, dimension)
 }
 
@@ -508,9 +505,9 @@ func (mock *StorerMock) InsertDimensionCalls() []struct {
 		InstanceID string
 		Dimension  *models.Dimension
 	}
-	lockStorerMockInsertDimension.RLock()
+	mock.lockInsertDimension.RLock()
 	calls = mock.calls.InsertDimension
-	lockStorerMockInsertDimension.RUnlock()
+	mock.lockInsertDimension.RUnlock()
 	return calls
 }
 
@@ -526,9 +523,9 @@ func (mock *StorerMock) InstanceExists(ctx context.Context, instanceID string) (
 		Ctx:        ctx,
 		InstanceID: instanceID,
 	}
-	lockStorerMockInstanceExists.Lock()
+	mock.lockInstanceExists.Lock()
 	mock.calls.InstanceExists = append(mock.calls.InstanceExists, callInfo)
-	lockStorerMockInstanceExists.Unlock()
+	mock.lockInstanceExists.Unlock()
 	return mock.InstanceExistsFunc(ctx, instanceID)
 }
 
@@ -543,8 +540,8 @@ func (mock *StorerMock) InstanceExistsCalls() []struct {
 		Ctx        context.Context
 		InstanceID string
 	}
-	lockStorerMockInstanceExists.RLock()
+	mock.lockInstanceExists.RLock()
 	calls = mock.calls.InstanceExists
-	lockStorerMockInstanceExists.RUnlock()
+	mock.lockInstanceExists.RUnlock()
 	return calls
 }


### PR DESCRIPTION
### What

Update to use dp-api-clients-go v.2.0.6-beta
Trello - https://trello.com/c/4qMsreiP/5162-update-services-to-use-dataset-api-etag-if-match-8

### How to review

Confirm changes are correct

### Who can review

Anyone
