### PR TITLE
use new patch dimensions functionality to update multiple node_ids and orders in a single call

### DIFF
--- a/client/dimensions_api.go
+++ b/client/dimensions_api.go
@@ -3,8 +3,9 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 
-	dataset "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 	"github.com/ONSdigital/dp-dimension-importer/config"
 	"github.com/ONSdigital/dp-dimension-importer/model"
@@ -27,10 +28,13 @@ var ErrNoDatastore = errors.New("data store is required but is not provided")
 // ErrInstanceIDEmpty is returned when an InstanceID is not provided to a call that requires it
 var ErrInstanceIDEmpty = errors.New("instance id is required but is empty")
 
+// ErrDimensionsNil is returned when a dimension array is not provided to a call that requires it
+var ErrDimensionsNil = errors.New("dimension array is required but is nil or empty")
+
 // ErrDimensionNil is returned when a dimension is not provided to a call that requires it
 var ErrDimensionNil = errors.New("dimension is required but is nil")
 
-//ErrDimensionIDEmpty is returned when a dimension with an empty ID is provided to a call that requires it
+// ErrDimensionIDEmpty is returned when a dimension with an empty ID is provided to a call that requires it
 var ErrDimensionIDEmpty = errors.New("dimension.id is required but is empty")
 
 // IClient is an interface that represents the required functionality from dataset client from dp-api-clients-go
@@ -53,7 +57,7 @@ type DatasetAPI struct {
 // NewDatasetAPIClient validates the parameters and creates a new dataset API client from dp-api-clients-go library.
 func NewDatasetAPIClient(cfg *config.Config) (*DatasetAPI, error) {
 	if len(cfg.DatasetAPIAddr) == 0 {
-		return nil, ErrHostEmpty
+		return nil, fmt.Errorf("error creating new dataset api client: %w", ErrHostEmpty)
 	}
 	return &DatasetAPI{
 		AuthToken:      cfg.ServiceAuthToken,
@@ -67,7 +71,7 @@ func NewDatasetAPIClient(cfg *config.Config) (*DatasetAPI, error) {
 // GetInstance retrieve the specified instance from the Dataset API.
 func (api DatasetAPI) GetInstance(ctx context.Context, instanceID string) (*model.Instance, error) {
 	if len(instanceID) == 0 {
-		return &model.Instance{}, ErrInstanceIDEmpty
+		return &model.Instance{}, fmt.Errorf("error getting instance: %w", ErrInstanceIDEmpty)
 	}
 	datasetInstance, _, err := api.Client.GetInstance(ctx, "", api.AuthToken, "", instanceID, headers.IfMatchAnyETag)
 	if err != nil {
@@ -79,7 +83,7 @@ func (api DatasetAPI) GetInstance(ctx context.Context, instanceID string) (*mode
 // GetDimensions retrieve the dimensions of the specified instance from the Dataset API
 func (api DatasetAPI) GetDimensions(ctx context.Context, instanceID string, ifMatch string) ([]*model.Dimension, error) {
 	if len(instanceID) == 0 {
-		return nil, ErrInstanceIDEmpty
+		return nil, fmt.Errorf("error getting dimensions: %w", ErrInstanceIDEmpty)
 	}
 
 	dimensions, _, err := api.Client.GetInstanceDimensionsInBatches(ctx, api.AuthToken, instanceID, api.BatchSize, api.MaxWorkers)
@@ -88,13 +92,16 @@ func (api DatasetAPI) GetDimensions(ctx context.Context, instanceID string, ifMa
 	}
 
 	ret := []*model.Dimension{}
-	for _, dim := range dimensions.Items {
-		ret = append(ret, model.NewDimension(&dim))
+	for i := range dimensions.Items {
+		ret = append(ret, model.NewDimension(&dimensions.Items[i]))
 	}
 	return ret, nil
 }
 
 // PatchDimensionOption makes an HTTP patch request to update the node_id and/or order for multiple dimension options
 func (api DatasetAPI) PatchDimensionOption(ctx context.Context, instanceID string, updates []*dataset.OptionUpdate) (string, error) {
+	if len(instanceID) == 0 {
+		return "", fmt.Errorf("error patching dimensions: %w", ErrInstanceIDEmpty)
+	}
 	return api.Client.PatchInstanceDimensions(ctx, api.AuthToken, instanceID, nil, updates, headers.IfMatchAnyETag)
 }

--- a/client/dimensions_api.go
+++ b/client/dimensions_api.go
@@ -16,10 +16,16 @@ import (
 const packageName = "client.DatasetAPI"
 
 // ErrHostEmpty is returned when a Client is created with an empty Host
-var ErrHostEmpty = errors.New("validation error: api host is required but was empty")
+var ErrHostEmpty = errors.New("api host is required but was empty")
+
+// ErrNoDatasetAPI is returned when a dataset API Client is not provided
+var ErrNoDatasetAPI = errors.New("dataset api is required but is not provided")
+
+// ErrNoDatastore is returned when a data store is not provided
+var ErrNoDatastore = errors.New("data store is required but is not provided")
 
 // ErrInstanceIDEmpty is returned when an InstanceID is not provided to a call that requires it
-var ErrInstanceIDEmpty = errors.New("validation error: instance id is required but is empty")
+var ErrInstanceIDEmpty = errors.New("instance id is required but is empty")
 
 // ErrDimensionNil is returned when a dimension is not provided to a call that requires it
 var ErrDimensionNil = errors.New("dimension is required but is nil")

--- a/client/dimensions_api_test.go
+++ b/client/dimensions_api_test.go
@@ -56,7 +56,7 @@ func TestNewClient(t *testing.T) {
 
 		Convey("Then a nil instance and ErrHostEmpty is returned", func() {
 			So(datasetAPI, ShouldEqual, nil)
-			So(err.Error(), ShouldResemble, client.ErrHostEmpty.Error())
+			So(err.Error(), ShouldEqual, client.ErrHostEmpty.Error())
 		})
 	})
 }
@@ -85,7 +85,7 @@ func TestGetInstance(t *testing.T) {
 				So(err, ShouldEqual, nil)
 			})
 
-			Convey("And dataset.GetInstance is called exactly once with the right parameters", func() {
+			Convey("Then dataset.GetInstance is called exactly once with the right parameters", func() {
 				So(len(clientMock.GetInstanceCalls()), ShouldEqual, 1)
 				So(clientMock.GetInstanceCalls()[0].InstanceID, ShouldEqual, instanceID)
 				So(clientMock.GetInstanceCalls()[0].ServiceAuthToken, ShouldEqual, authToken)
@@ -139,7 +139,7 @@ func TestGetInstance(t *testing.T) {
 				So(err, ShouldResemble, errMock)
 			})
 
-			Convey("And dataset.GetInstance is called exactly once with the right parameters", func() {
+			Convey("Then dataset.GetInstance is called exactly once with the right parameters", func() {
 				So(len(clientMock.GetInstanceCalls()), ShouldEqual, 1)
 				So(clientMock.GetInstanceCalls()[0].InstanceID, ShouldEqual, instanceID)
 				So(clientMock.GetInstanceCalls()[0].ServiceAuthToken, ShouldEqual, authToken)
@@ -174,7 +174,7 @@ func TestGetDimensions(t *testing.T) {
 				So(err, ShouldEqual, nil)
 			})
 
-			Convey("And dataset.GetInstanceDimensions is called exactly once with the right parameters", func() {
+			Convey("Then dataset.GetInstanceDimensions is called exactly once with the right parameters", func() {
 				So(len(clientMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 1)
 				So(clientMock.GetInstanceDimensionsInBatchesCalls()[0].InstanceID, ShouldEqual, instanceID)
 				So(clientMock.GetInstanceDimensionsInBatchesCalls()[0].ServiceAuthToken, ShouldEqual, authToken)
@@ -226,7 +226,7 @@ func TestGetDimensions(t *testing.T) {
 				So(err, ShouldResemble, errMock)
 			})
 
-			Convey("And dataset.GetInstanceDimensions is called exactly once with the right parameters", func() {
+			Convey("Then dataset.GetInstanceDimensions is called exactly once with the right parameters", func() {
 				So(len(clientMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 1)
 				So(clientMock.GetInstanceDimensionsInBatchesCalls()[0].InstanceID, ShouldEqual, instanceID)
 				So(clientMock.GetInstanceDimensionsInBatchesCalls()[0].ServiceAuthToken, ShouldEqual, authToken)
@@ -264,7 +264,7 @@ func TestDatasetAPI_PatchDimensionOption(t *testing.T) {
 				So(err, ShouldResemble, errMock)
 			})
 
-			Convey("And dataset.PatchInstanceDimensions is called exactly once with the right parameters", func() {
+			Convey("Then dataset.PatchInstanceDimensions is called exactly once with the right parameters", func() {
 				So(len(clientMock.PatchInstanceDimensionsCalls()), ShouldEqual, 1)
 				So(clientMock.PatchInstanceDimensionsCalls()[0].ServiceAuthToken, ShouldEqual, authToken)
 				So(clientMock.PatchInstanceDimensionsCalls()[0].InstanceID, ShouldEqual, instanceID)
@@ -295,7 +295,7 @@ func TestDatasetAPI_PatchDimensionOption(t *testing.T) {
 				So(err, ShouldEqual, nil)
 			})
 
-			Convey("And dataset.PatchInstanceDimensionOption is called exactly once with the right parameters", func() {
+			Convey("Then dataset.PatchInstanceDimensionOption is called exactly once with the right parameters", func() {
 				So(len(clientMock.PatchInstanceDimensionsCalls()), ShouldEqual, 1)
 				So(clientMock.PatchInstanceDimensionsCalls()[0].ServiceAuthToken, ShouldEqual, authToken)
 				So(clientMock.PatchInstanceDimensionsCalls()[0].InstanceID, ShouldEqual, instanceID)

--- a/client/dimensions_api_test.go
+++ b/client/dimensions_api_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"testing"
 
-	dataset "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 	"github.com/ONSdigital/dp-dimension-importer/client"
 	"github.com/ONSdigital/dp-dimension-importer/config"
@@ -56,7 +56,7 @@ func TestNewClient(t *testing.T) {
 
 		Convey("Then a nil instance and ErrHostEmpty is returned", func() {
 			So(datasetAPI, ShouldEqual, nil)
-			So(err.Error(), ShouldEqual, client.ErrHostEmpty.Error())
+			So(err.Error(), ShouldEqual, "error creating new dataset api client: api host is required but was empty")
 		})
 	})
 }
@@ -111,7 +111,7 @@ func TestGetInstance(t *testing.T) {
 
 			Convey("Then the expected error is returned", func() {
 				So(instance, ShouldResemble, &model.Instance{})
-				So(err, ShouldResemble, client.ErrInstanceIDEmpty)
+				So(err.Error(), ShouldEqual, "error getting instance: instance id is required but is empty")
 			})
 		})
 	})
@@ -198,7 +198,7 @@ func TestGetDimensions(t *testing.T) {
 
 			Convey("Then the expected error is returned", func() {
 				So(dims, ShouldEqual, nil)
-				So(err, ShouldResemble, client.ErrInstanceIDEmpty)
+				So(err.Error(), ShouldEqual, "error getting dimensions: instance id is required but is empty")
 			})
 		})
 	})

--- a/client/dimensions_api_test.go
+++ b/client/dimensions_api_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	dataset "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 	"github.com/ONSdigital/dp-dimension-importer/client"
 	"github.com/ONSdigital/dp-dimension-importer/config"
 	"github.com/ONSdigital/dp-dimension-importer/mocks"
@@ -235,146 +236,72 @@ func TestGetDimensions(t *testing.T) {
 }
 
 func TestDatasetAPI_PatchDimensionOption(t *testing.T) {
+	updates := []*dataset.OptionUpdate{
+		{
+			Name:   dimensionOne.DbModel().DimensionID,
+			Option: dimensionOne.DbModel().Option,
+			NodeID: dimensionOne.DbModel().NodeID,
+		},
+	}
 
-	Convey("Given no instanceID is provided", t, func() {
-		clientMock := &mocks.IClientMock{}
-
-		datasetAPI := client.DatasetAPI{
-			AuthToken:         authToken,
-			DatasetAPIHost:    host,
-			Client:            clientMock,
-			EnablePatchNodeID: true,
-		}
-
-		Convey("When PatchDimensionOption is called", func() {
-			_, err := datasetAPI.PatchDimensionOption(ctx, "", dimensionOne, nil)
-
-			Convey("Then the expected error is returned", func() {
-				So(err, ShouldResemble, client.ErrInstanceIDEmpty)
-			})
-		})
-	})
-
-	Convey("Given no dimension is provided", t, func() {
-		clientMock := &mocks.IClientMock{}
-
-		datasetAPI := client.DatasetAPI{
-			AuthToken:         authToken,
-			DatasetAPIHost:    host,
-			Client:            clientMock,
-			EnablePatchNodeID: true,
-		}
-
-		Convey("When PatchDimensionOption is called", func() {
-			_, err := datasetAPI.PatchDimensionOption(ctx, instanceID, nil, nil)
-
-			Convey("Then the expected error is returned", func() {
-				So(err, ShouldResemble, client.ErrDimensionNil)
-			})
-		})
-	})
-
-	Convey("Given a dimension with an empty dimensionID", t, func() {
-		clientMock := &mocks.IClientMock{}
-
-		datasetAPI := client.DatasetAPI{
-			AuthToken:         authToken,
-			DatasetAPIHost:    host,
-			Client:            clientMock,
-			EnablePatchNodeID: true,
-		}
-
-		Convey("When PatchDimensionOption is called", func() {
-			emptyDimension := model.NewDimension(&dataset.Dimension{})
-			_, err := datasetAPI.PatchDimensionOption(ctx, instanceID, emptyDimension, nil)
-
-			Convey("Then the expected error is returned", func() {
-				So(err, ShouldResemble, client.ErrDimensionIDEmpty)
-			})
-		})
-	})
-
-	Convey("Given dataset.PatchInstanceDimensionOption will return an error", t, func() {
+	Convey("Given dataset.PatchInstanceDimensions will return an error", t, func() {
 		clientMock := &mocks.IClientMock{
-			PatchInstanceDimensionOptionFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, dimensionID string, optionID string, nodeID string, order *int, ifMatch string) (string, error) {
+			PatchInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, upserts []*dataset.OptionPost, updates []*dataset.OptionUpdate, ifMatch string) (string, error) {
 				return "", errMock
 			},
 		}
 
 		datasetAPI := client.DatasetAPI{
-			AuthToken:         authToken,
-			DatasetAPIHost:    host,
-			Client:            clientMock,
-			EnablePatchNodeID: true,
+			AuthToken:      authToken,
+			DatasetAPIHost: host,
+			Client:         clientMock,
 		}
 
-		Convey("When PatchDimensionOption is called", func() {
-			_, err := datasetAPI.PatchDimensionOption(ctx, instanceID, dimensionOne, nil)
+		Convey("When PatchDimensionOption is called with an update", func() {
+			_, err := datasetAPI.PatchDimensionOption(ctx, instanceID, updates)
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldResemble, errMock)
 			})
 
-			Convey("And dataset.PatchInstanceDimensionOption is called exactly once with the right parameters", func() {
-				So(len(clientMock.PatchInstanceDimensionOptionCalls()), ShouldEqual, 1)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].ServiceAuthToken, ShouldEqual, authToken)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].DimensionID, ShouldEqual, dimensionOne.DbModel().DimensionID)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].InstanceID, ShouldEqual, instanceID)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].OptionID, ShouldEqual, dimensionOne.DbModel().Option)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].NodeID, ShouldEqual, dimensionOne.DbModel().NodeID)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].Order, ShouldBeNil)
+			Convey("And dataset.PatchInstanceDimensions is called exactly once with the right parameters", func() {
+				So(len(clientMock.PatchInstanceDimensionsCalls()), ShouldEqual, 1)
+				So(clientMock.PatchInstanceDimensionsCalls()[0].ServiceAuthToken, ShouldEqual, authToken)
+				So(clientMock.PatchInstanceDimensionsCalls()[0].InstanceID, ShouldEqual, instanceID)
+				So(clientMock.PatchInstanceDimensionsCalls()[0].Upserts, ShouldBeNil)
+				So(clientMock.PatchInstanceDimensionsCalls()[0].Updates, ShouldResemble, updates)
+				So(clientMock.PatchInstanceDimensionsCalls()[0].IfMatch, ShouldEqual, headers.IfMatchAnyETag)
 			})
 		})
 	})
 
 	Convey("Given dataset.PatchInstanceDimensionOption succeeds", t, func() {
 		clientMock := &mocks.IClientMock{
-			PatchInstanceDimensionOptionFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, dimensionID string, optionID string, nodeID string, order *int, ifMatch string) (string, error) {
+			PatchInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, upserts []*dataset.OptionPost, updates []*dataset.OptionUpdate, ifMatch string) (string, error) {
 				return "", nil
 			},
 		}
 
 		datasetAPI := client.DatasetAPI{
-			AuthToken:         authToken,
-			DatasetAPIHost:    host,
-			Client:            clientMock,
-			EnablePatchNodeID: true,
+			AuthToken:      authToken,
+			DatasetAPIHost: host,
+			Client:         clientMock,
 		}
 
 		Convey("When PatchDimensionOption is called", func() {
-			_, err := datasetAPI.PatchDimensionOption(ctx, instanceID, dimensionOne, nil)
+			_, err := datasetAPI.PatchDimensionOption(ctx, instanceID, updates)
 
 			Convey("Then no error is returned", func() {
 				So(err, ShouldEqual, nil)
 			})
 
 			Convey("And dataset.PatchInstanceDimensionOption is called exactly once with the right parameters", func() {
-				So(len(clientMock.PatchInstanceDimensionOptionCalls()), ShouldEqual, 1)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].ServiceAuthToken, ShouldEqual, authToken)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].DimensionID, ShouldEqual, dimensionOne.DbModel().DimensionID)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].InstanceID, ShouldEqual, instanceID)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].OptionID, ShouldEqual, dimensionOne.DbModel().Option)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].NodeID, ShouldEqual, dimensionOne.DbModel().NodeID)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].Order, ShouldBeNil)
-			})
-		})
-
-		Convey("When PatchDimensionOption is called forcing the NodeID to be ignored", func() {
-			datasetAPI.EnablePatchNodeID = false
-			_, err := datasetAPI.PatchDimensionOption(ctx, instanceID, dimensionOne, nil)
-
-			Convey("Then no error is returned", func() {
-				So(err, ShouldEqual, nil)
-			})
-
-			Convey("And dataset.PatchInstanceDimensionOption is called exactly once to update the order only", func() {
-				So(len(clientMock.PatchInstanceDimensionOptionCalls()), ShouldEqual, 1)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].ServiceAuthToken, ShouldEqual, authToken)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].DimensionID, ShouldEqual, dimensionOne.DbModel().DimensionID)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].InstanceID, ShouldEqual, instanceID)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].OptionID, ShouldEqual, dimensionOne.DbModel().Option)
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].NodeID, ShouldEqual, "")
-				So(clientMock.PatchInstanceDimensionOptionCalls()[0].Order, ShouldBeNil)
+				So(len(clientMock.PatchInstanceDimensionsCalls()), ShouldEqual, 1)
+				So(clientMock.PatchInstanceDimensionsCalls()[0].ServiceAuthToken, ShouldEqual, authToken)
+				So(clientMock.PatchInstanceDimensionsCalls()[0].InstanceID, ShouldEqual, instanceID)
+				So(clientMock.PatchInstanceDimensionsCalls()[0].Upserts, ShouldBeNil)
+				So(clientMock.PatchInstanceDimensionsCalls()[0].Updates, ShouldResemble, updates)
+				So(clientMock.PatchInstanceDimensionsCalls()[0].IfMatch, ShouldEqual, headers.IfMatchAnyETag)
 			})
 		})
 	})

--- a/cmd/dp-dimension-importer/main.go
+++ b/cmd/dp-dimension-importer/main.go
@@ -90,10 +90,11 @@ func main() {
 
 	// Receiver for NewInstance events.
 	instanceEventHandler := &handler.InstanceEventHandler{
-		Store:         graphDB,
-		DatasetAPICli: datasetAPICli,
-		Producer:      instanceCompletedProducer,
-		BatchSize:     cfg.BatchSize,
+		Store:             graphDB,
+		DatasetAPICli:     datasetAPICli,
+		Producer:          instanceCompletedProducer,
+		BatchSize:         cfg.BatchSize,
+		EnablePatchNodeID: cfg.EnablePatchNodeID,
 	}
 
 	// Errors handler

--- a/cmd/dp-dimension-importer/main.go
+++ b/cmd/dp-dimension-importer/main.go
@@ -87,6 +87,9 @@ func main() {
 
 	// Dataset Client wrapper.
 	datasetAPICli, err := client.NewDatasetAPIClient(cfg)
+	if err != nil {
+		os.Exit(1)
+	}
 
 	// Receiver for NewInstance events.
 	instanceEventHandler := &handler.InstanceEventHandler{
@@ -129,8 +132,8 @@ func main() {
 	errorReporterProducer.Channels().LogErrors(ctx, "error reporter kafka producer received an error")
 
 	// If we receive a signal (SIGINT or SIGTERM), start graceful shutdown
-	signal := <-signals
-	log.Info(ctx, "os signal received, attempting graceful shutdown", log.Data{"signal": signal.String()})
+	s := <-signals
+	log.Info(ctx, "os signal received, attempting graceful shutdown", log.Data{"signal": s.String()})
 
 	shutdownCtx, cancel := context.WithTimeout(ctx, cfg.GracefulShutdownTimeout)
 	hasShutdownError := false
@@ -263,7 +266,7 @@ func registerCheckers(hc *healthcheck.HealthCheck,
 	}
 
 	if hasErrors {
-		return errors.New("Error(s) registering checkers for healthcheck")
+		return errors.New("error(s) registering checkers for healthcheck")
 	}
 	return nil
 }

--- a/cmd/producer/main.go
+++ b/cmd/producer/main.go
@@ -42,8 +42,8 @@ func main() {
 		FileURL:    *file,
 	}
 
-	bytes, error := schema.NewInstanceSchema.Marshal(dimensionsInsertedEvent)
-	if error != nil {
+	bytes, err := schema.NewInstanceSchema.Marshal(dimensionsInsertedEvent)
+	if err != nil {
 		log.Fatal(ctx, "error marshalling dimensions inserted event", err)
 		os.Exit(1)
 	}
@@ -52,5 +52,8 @@ func main() {
 	// give Kafka time to produce the message before closing the producer
 	time.Sleep(time.Second)
 
-	producer.Close(nil)
+	if err := producer.Close(ctx); err != nil {
+		log.Fatal(ctx, "error closing producer", err)
+		os.Exit(1)
+	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	KafkaVersion                   string        `envconfig:"KAFKA_VERSION"`
 	KafkaOffsetOldest              bool          `envconfig:"KAFKA_OFFSET_OLDEST"`
 	KafkaNumWorkers                int           `envconfig:"KAFKA_NUM_WORKERS"` // maximum number of concurent kafka messages being consumed at the same time
-	BatchSize                      int           `envconfig:"BATCH_SIZE"`        // Number of kafka messages that will be batched
+	BatchSize                      int           `envconfig:"BATCH_SIZE"`        // number of kafka messages that will be batched
 	IncomingInstancesTopic         string        `envconfig:"DIMENSIONS_EXTRACTED_TOPIC"`
 	IncomingInstancesConsumerGroup string        `envconfig:"DIMENSIONS_EXTRACTED_CONSUMER_GROUP"`
 	OutgoingInstancesTopic         string        `envconfig:"DIMENSIONS_INSERTED_TOPIC"`
@@ -47,7 +47,7 @@ func Get(ctx context.Context) (*Config, error) {
 		KafkaVersion:                   "1.0.2",
 		KafkaOffsetOldest:              true,
 		KafkaNumWorkers:                1,
-		BatchSize:                      1, //not all implementations will allow for batching, so set to a safe default
+		BatchSize:                      1, // not all implementations will allow for batching, so set to a safe default
 		IncomingInstancesTopic:         "dimensions-extracted",
 		IncomingInstancesConsumerGroup: "dp-dimension-importer",
 		OutgoingInstancesTopic:         "dimensions-inserted",
@@ -79,6 +79,6 @@ func Get(ctx context.Context) (*Config, error) {
 // String is implemented to prevent sensitive fields being logged.
 // The config is returned as JSON with sensitive fields omitted.
 func (config Config) String() string {
-	json, _ := json.Marshal(config)
-	return string(json)
+	b, _ := json.Marshal(config)
+	return string(b)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-dimension-importer
 go 1.16
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.2.1-0.20210922124615-04bfb655a194
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.3.0
 	github.com/ONSdigital/dp-graph/v2 v2.13.1
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-kafka/v2 v2.2.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-dimension-importer
 go 1.16
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.2.1-0.20210922124615-04bfb655a194
 	github.com/ONSdigital/dp-graph/v2 v2.13.1
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-kafka/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.36.0/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-api-clients-go v1.41.1 h1:xkeT6dCTFSAoBpZxgiJUiuqgcfjCX+c52CIiZo1Y2iU=
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta h1:Wbjibp0/LLoRewWQfmbWw26iKDixw+iiA42OQgRqTQ4=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.0.6-beta/go.mod h1:zN8+84r1tWgyCmypku7JFN63nCMOGTIM26zf5GwHkJ4=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.2.1-0.20210922124615-04bfb655a194 h1:+HB3yHGoYqidh93X/PGdU1cH6D9GU8T02BAkRIdNZyE=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.2.1-0.20210922124615-04bfb655a194/go.mod h1:do31xNC5k22vAMnbnXGT9NH/7MLAsfR0qeTfiItw/mA=
 github.com/ONSdigital/dp-graph/v2 v2.13.1 h1:txp2WOtmA/S3g4BzcZ2uxcSvp0nBUtZTzWjkbDrSHqs=
 github.com/ONSdigital/dp-graph/v2 v2.13.1/go.mod h1:goNf7IF+hJATF9F8DD8QAHNF38s/0wRMzgHxzOamDKo=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
@@ -130,6 +130,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.36.0/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-api-clients-go v1.41.1 h1:xkeT6dCTFSAoBpZxgiJUiuqgcfjCX+c52CIiZo1Y2iU=
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.2.1-0.20210922124615-04bfb655a194 h1:+HB3yHGoYqidh93X/PGdU1cH6D9GU8T02BAkRIdNZyE=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.2.1-0.20210922124615-04bfb655a194/go.mod h1:do31xNC5k22vAMnbnXGT9NH/7MLAsfR0qeTfiItw/mA=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.3.0 h1:w0tTGRf3Y/2mvGh5fZ5zVZyukCVAjHsZjgcfvAI2YoA=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.3.0/go.mod h1:do31xNC5k22vAMnbnXGT9NH/7MLAsfR0qeTfiItw/mA=
 github.com/ONSdigital/dp-graph/v2 v2.13.1 h1:txp2WOtmA/S3g4BzcZ2uxcSvp0nBUtZTzWjkbDrSHqs=
 github.com/ONSdigital/dp-graph/v2 v2.13.1/go.mod h1:goNf7IF+hJATF9F8DD8QAHNF38s/0wRMzgHxzOamDKo=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/handler/incoming_instance_handler_test.go
+++ b/handler/incoming_instance_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
@@ -88,6 +89,119 @@ var (
 	errorMock = errors.New("mock error")
 )
 
+func validateDatastGetSuccessful(datasetAPIMock *mocks.IClientMock) {
+	Convey("Then DatasetAPICli.GetInstanceDimensions is called 1 time with the expected parameters", func() {
+		So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
+		So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()[0].InstanceID, ShouldEqual, testInstanceID)
+		So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()[0].BatchSize, ShouldEqual, testBatchSize)
+	})
+
+	Convey("Then DatasetAPICli.GetInstance is called 1 time with the expected paramters", func() {
+		So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
+		So(datasetAPIMock.GetInstanceCalls()[0].InstanceID, ShouldEqual, testInstanceID)
+	})
+}
+
+func validateCreateInstanceSuccessful(storerMock *storertest.StorerMock) {
+	Convey("And storer.InstanceExists is called 1 time with the expected parameters to check that the instance did not exist already", func() {
+		calls := storerMock.InstanceExistsCalls()
+		So(calls, ShouldHaveLength, 1)
+		So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+	})
+
+	Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
+		calls := storerMock.CreateInstanceCalls()
+		So(calls, ShouldHaveLength, 1)
+		So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+	})
+}
+
+func validateInsertDimensionsSuccessful(t *testing.T, datasetAPIMock *mocks.IClientMock, storeMock *storertest.StorerMock) {
+	Convey("And storerMock.InsertDimension is called 2 times with the expected parameters", func() {
+		validateStorerInsertDimensionCalls(storeMock, 3, instance.DbModel().InstanceID, d1.DbModel(), d2.DbModel(), d3.DbModel())
+	})
+
+	Convey("And storerMock.GetCodeOrder is called 2 times with the expected paramters", func() {
+		calls := storeMock.GetCodesOrderCalls()
+		So(calls, ShouldHaveLength, 2)
+		So(calls[0].CodeListID, ShouldEqual, testCodeListID)
+		So(calls[1].CodeListID, ShouldEqual, testCodeListID)
+		So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option}) // first batch
+		So(calls[1].Codes, ShouldResemble, []string{d3Api.Option})               // second batch (not full size)
+	})
+
+	Convey("And DatasetAPICli.PatchDimensionOption is called 2 time with the expected parameters", func() {
+		calls := datasetAPIMock.PatchInstanceDimensionsCalls()
+		So(calls, ShouldHaveLength, 2)
+
+		So(calls[0].InstanceID, ShouldEqual, testInstanceID)
+		So(calls[0].Upserts, ShouldBeNil)
+		So(calls[0].Updates, ShouldResemble, []*dataset.OptionUpdate{ // first batch
+			{
+				Name:   d1Api.DimensionID,
+				Option: d1Api.Option,
+				NodeID: d1Api.NodeID,
+				Order:  &d1Order,
+			},
+			{
+				Name:   d2Api.DimensionID,
+				Option: d2Api.Option,
+				NodeID: d2Api.NodeID,
+				Order:  &d2Order,
+			},
+		})
+
+		So(calls[1].InstanceID, ShouldEqual, testInstanceID)
+		So(calls[1].Upserts, ShouldBeNil)
+		So(calls[1].Updates, ShouldResemble, []*dataset.OptionUpdate{ // second batch
+			{
+				Name:   d3Api.DimensionID,
+				Option: d3Api.Option,
+				NodeID: d3Api.NodeID,
+			},
+		})
+	})
+
+	Convey("And store.AddDimensions is called 1 time with the expected parameters", func() {
+		calls := storeMock.AddDimensionsCalls()
+		So(calls, ShouldHaveLength, 1)
+
+		So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+		So(calls[0].Dimensions, ShouldResemble, instance.DbModel().Dimensions)
+	})
+
+	Convey("And store.CreateCodeRelationshipCalls is called 3 times with the expected parameters", func() {
+		calls := storeMock.CreateCodeRelationshipCalls()
+		So(calls, ShouldHaveLength, 3)
+
+		// Validate expected calls (in any order)
+		d1Called := false
+		d2Called := false
+		d3Called := false
+		for _, call := range calls {
+			switch call.Code {
+			case d1.DbModel().Option:
+				So(d1Called, ShouldBeFalse) // called only once
+				d1Called = true
+				So(call.CodeListID, ShouldEqual, testCodeListID)
+				So(call.InstanceID, ShouldEqual, testInstanceID)
+			case d2.DbModel().Option:
+				So(d2Called, ShouldBeFalse) // called only once
+				d2Called = true
+				So(call.CodeListID, ShouldEqual, testCodeListID)
+				So(call.InstanceID, ShouldEqual, testInstanceID)
+			case d3.DbModel().Option:
+				So(d3Called, ShouldBeFalse) // called only once
+				d3Called = true
+				So(call.CodeListID, ShouldEqual, testCodeListID)
+				So(call.InstanceID, ShouldEqual, testInstanceID)
+			default:
+				t.Fail()
+			}
+		}
+	})
+}
+
 func TestInstanceEventHandler_Handle(t *testing.T) {
 
 	Convey("Given a successful handler", t, func() {
@@ -99,84 +213,9 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 
 		Convey("When a valid event is handled", func() {
 			handler.Handle(ctx, newInstance)
-
-			Convey("Then DatasetAPICli.GetInstanceDimensions is called 1 time with the expected parameters", func() {
-				So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
-				So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()[0].InstanceID, ShouldEqual, testInstanceID)
-				So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()[0].BatchSize, ShouldEqual, testBatchSize)
-			})
-
-			Convey("Then DatasetAPICli.GetInstance is called 1 time with the expected paramters", func() {
-				So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
-				So(datasetAPIMock.GetInstanceCalls()[0].InstanceID, ShouldEqual, testInstanceID)
-			})
-
-			Convey("And storerMock.InsertDimension is called 2 times with the expected parameters", func() {
-				validateInsertDimensionCalls(storeMock, 3, instance.DbModel().InstanceID, d1.DbModel(), d2.DbModel(), d3.DbModel())
-			})
-
-			Convey("And storerMock.GetCodeOrder is called 2 times with the expected paramters", func() {
-				calls := storeMock.GetCodesOrderCalls()
-				So(calls, ShouldHaveLength, 2)
-				So(calls[0].CodeListID, ShouldEqual, testCodeListID)
-				So(calls[1].CodeListID, ShouldEqual, testCodeListID)
-				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option}) // first batch
-				So(calls[1].Codes, ShouldResemble, []string{d3Api.Option})               // second batch (not full size)
-			})
-
-			Convey("And DatasetAPICli.PatchDimensionOption is called 2 time with the expected parameters", func() {
-				calls := datasetAPIMock.PatchInstanceDimensionsCalls()
-				So(calls, ShouldHaveLength, 2)
-
-				So(calls[0].InstanceID, ShouldEqual, testInstanceID)
-				So(calls[0].Upserts, ShouldBeNil)
-				So(calls[0].Updates, ShouldResemble, []*dataset.OptionUpdate{ // first batch
-					{
-						Name:   d1Api.DimensionID,
-						Option: d1Api.Option,
-						NodeID: d1Api.NodeID,
-						Order:  &d1Order,
-					},
-					{
-						Name:   d2Api.DimensionID,
-						Option: d2Api.Option,
-						NodeID: d2Api.NodeID,
-						Order:  &d2Order,
-					},
-				})
-
-				So(calls[1].InstanceID, ShouldEqual, testInstanceID)
-				So(calls[1].Upserts, ShouldBeNil)
-				So(calls[1].Updates, ShouldResemble, []*dataset.OptionUpdate{ // second batch
-					{
-						Name:   d3Api.DimensionID,
-						Option: d3Api.Option,
-						NodeID: d3Api.NodeID,
-					},
-				})
-			})
-
-			Convey("And store.AddDimensions is called 1 time with the expected parameters", func() {
-				calls := storeMock.AddDimensionsCalls()
-				So(calls, ShouldHaveLength, 1)
-
-				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-				So(calls[0].Dimensions, ShouldResemble, instance.DbModel().Dimensions)
-			})
-
-			Convey("And store.CreateCodeRelationshipCalls is called 3 times with the expected parameters", func() {
-				calls := storeMock.CreateCodeRelationshipCalls()
-				So(calls, ShouldHaveLength, 3)
-
-				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-				So(calls[0].Code, ShouldResemble, d1.DbModel().Option)
-
-				So(calls[1].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-				So(calls[1].Code, ShouldResemble, d2.DbModel().Option)
-
-				So(calls[2].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-				So(calls[2].Code, ShouldResemble, d3.DbModel().Option)
-			})
+			validateDatastGetSuccessful(datasetAPIMock)
+			validateCreateInstanceSuccessful(storeMock)
+			validateInsertDimensionsSuccessful(t, datasetAPIMock, storeMock)
 
 			Convey("And store is called once to create constraints for the expected instanceID", func() {
 				So(storeMock.CreateInstanceConstraintCalls(), ShouldHaveLength, 1)
@@ -191,12 +230,66 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		})
 	})
 
+	Convey("Given a handler with a dataset api patch endpoint that fails from the third call onwards", t, func() {
+		// Set up mocks
+		storeMock := storerMockHappy()
+		numCall := 0
+		numCallLock := sync.Mutex{}
+		datasetAPIMock := datasetAPIMockHappy()
+		storeMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
+			defer numCallLock.Unlock()
+			numCallLock.Lock()
+			numCall++
+			if numCall <= 2 {
+				return dimension, nil
+			}
+			return dimension, errorMock
+		}
+		handler := setUp(storeMock, datasetAPIMock, nil)
+
+		Convey("When a valid event is handled", func() {
+			handler.Handle(ctx, newInstance)
+			validateDatastGetSuccessful(datasetAPIMock)
+			validateCreateInstanceSuccessful(storeMock)
+
+			Convey("And storerMock.InsertDimension is called three times, where the third call will fail", func() {
+				validateStorerInsertDimensionCalls(storeMock, 3, instance.DbModel().InstanceID, d1.DbModel(), d2.DbModel(), d3.DbModel())
+			})
+
+			Convey("And storerMock.GetCodeOrder is called only once with the expected paramters for the first batch", func() {
+				calls := storeMock.GetCodesOrderCalls()
+				So(calls, ShouldHaveLength, 1)
+				So(calls[0].CodeListID, ShouldEqual, testCodeListID)
+				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option}) // first batch
+			})
+
+			Convey("And DatasetAPICli.PatchDimensionOption is called 1 time during the first batch handling", func() {
+				calls := datasetAPIMock.PatchInstanceDimensionsCalls()
+				So(calls, ShouldHaveLength, 1)
+			})
+
+			Convey("And store.AddDimensions is not called", func() {
+				calls := storeMock.AddDimensionsCalls()
+				So(calls, ShouldHaveLength, 0)
+			})
+
+			Convey("And store.CreateCodeRelationshipCalls is called twice (for the first batch)", func() {
+				calls := storeMock.CreateCodeRelationshipCalls()
+				So(calls, ShouldHaveLength, 2)
+			})
+
+			Convey("And CreateInstanceConstraint is not called", func() {
+				So(storeMock.CreateInstanceConstraintCalls(), ShouldHaveLength, 0)
+			})
+		})
+	})
+
 	Convey("When an invalid event is handled", t, func() {
 		handler := setUp(nil, nil, nil)
 		err := handler.Handle(ctx, event.NewInstance{})
 
 		Convey("Then the appropriate error is returned", func() {
-			So(err.Error(), ShouldResemble, "validation error instance_id required but was empty")
+			So(err.Error(), ShouldEqual, "validation error: instance id is required but is empty")
 		})
 	})
 
@@ -220,6 +313,29 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		})
 	})
 
+	Convey("When DatasetAPICli.GetInstance returns an error", t, func() {
+		event := event.NewInstance{InstanceID: testInstanceID}
+
+		datasetAPIMock := datasetAPIMockHappy()
+		datasetAPIMock.GetInstanceFunc = func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
+			return dataset.Instance{}, "", errorMock
+		}
+		handler := setUp(nil, datasetAPIMock, nil)
+		err := handler.Handle(ctx, event)
+
+		Convey("Then the expected error is returned", func() {
+			So(err.Error(), ShouldEqual, fmt.Errorf("dataset api client get instance returned an error: %w", errorMock).Error())
+		})
+
+		Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1", func() {
+			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
+		})
+
+		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
+		})
+	})
+
 	Convey("When storer.CreateInstance returns an error", t, func() {
 		event := event.NewInstance{InstanceID: testInstanceID}
 
@@ -235,13 +351,7 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		handler := setUp(storerMock, datasetAPIMock, nil)
 		err := handler.Handle(ctx, event)
 
-		Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
-			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
-		})
-
-		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
-		})
+		validateDatastGetSuccessful(datasetAPIMock)
 
 		Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
 			calls := storerMock.CreateInstanceCalls()
@@ -258,6 +368,48 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		})
 	})
 
+	Convey("When DatasetAPICli.GetInstanceDimensions returns an empty list of dimensions without error", t, func() {
+		event := event.NewInstance{InstanceID: testInstanceID}
+
+		datasetAPIMock := &mocks.IClientMock{
+			GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, batchSize int, maxWorkers int) (dataset.Dimensions, string, error) {
+				return dataset.Dimensions{}, "", nil
+			},
+		}
+		handler := setUp(nil, datasetAPIMock, nil)
+		err := handler.Handle(ctx, event)
+
+		Convey("Then DatasetAPICli.GetInstanceDimensionsInBatchesCalls is called 1 time with the expected paramters", func() {
+			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
+			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()[0].InstanceID, ShouldEqual, testInstanceID)
+		})
+
+		Convey("Then the expected validation error is returned", func() {
+			So(err.Error(), ShouldEqual, fmt.Errorf("validation error: %w", client.ErrDimensionNil).Error())
+		})
+	})
+
+	Convey("When DatasetAPICli.GetInstance returns an empty instance without error", t, func() {
+		event := event.NewInstance{InstanceID: testInstanceID}
+
+		datasetAPIMock := &mocks.IClientMock{
+			GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, maxWorkers, batchSize int) (dataset.Dimensions, string, error) {
+				return dataset.Dimensions{Items: []dataset.Dimension{d1Api, d2Api, d3Api}}, "", nil
+			},
+			GetInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, ifMatch string) (dataset.Instance, string, error) {
+				return dataset.Instance{}, "", nil
+			},
+		}
+		handler := setUp(nil, datasetAPIMock, nil)
+		err := handler.Handle(ctx, event)
+
+		validateDatastGetSuccessful(datasetAPIMock)
+
+		Convey("Then the expected validation error is returned", func() {
+			So(err.Error(), ShouldEqual, fmt.Errorf("validation error: %w", client.ErrInstanceIDEmpty).Error())
+		})
+	})
+
 	Convey("When storer.CreateCodeRelationship returns an error", t, func() {
 		event := event.NewInstance{InstanceID: testInstanceID}
 
@@ -269,19 +421,8 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		handler := setUp(storerMock, datasetAPIMock, nil)
 		err := handler.Handle(ctx, event)
 
-		Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
-			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
-		})
-
-		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
-		})
-
-		Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
-			calls := storerMock.CreateInstanceCalls()
-			So(calls, ShouldHaveLength, 1)
-			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-		})
+		validateDatastGetSuccessful(datasetAPIMock)
+		validateCreateInstanceSuccessful(storerMock)
 
 		Convey("And storer.InsertDimension is called at least once with the expected instanceID and dimensionID", func() {
 			calls := storerMock.InsertDimensionCalls()
@@ -320,19 +461,8 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		handler := setUp(storerMock, datasetAPIMock, nil)
 		err := handler.Handle(ctx, event)
 
-		Convey("Then the DatasetAPICli.GetInstanceDimensionsCalls is called 1 time", func() {
-			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
-		})
-
-		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
-		})
-
-		Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
-			calls := storerMock.CreateInstanceCalls()
-			So(calls, ShouldHaveLength, 1)
-			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-		})
+		validateDatastGetSuccessful(datasetAPIMock)
+		validateCreateInstanceSuccessful(storerMock)
 
 		Convey("And storer.InsertDimension is called at least once with the expected parameters", func() {
 			calls := storerMock.InsertDimensionCalls()
@@ -352,7 +482,7 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		})
 	})
 
-	Convey("When storer.GetCodesOrder returns an error", t, func() {
+	Convey("When SetOrderAndNodeIDs returns an error (due to storer.GetCodesOrder returning an error)", t, func() {
 		event := event.NewInstance{InstanceID: testInstanceID}
 
 		datasetAPIMock := datasetAPIMockHappy()
@@ -363,19 +493,8 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		handler := setUp(storerMock, datasetAPIMock, nil)
 		err := handler.Handle(ctx, event)
 
-		Convey("Then the DatasetAPICli.GetInstanceDimensionsCalls is called 1 time", func() {
-			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
-		})
-
-		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
-		})
-
-		Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
-			calls := storerMock.CreateInstanceCalls()
-			So(calls, ShouldHaveLength, 1)
-			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-		})
+		validateDatastGetSuccessful(datasetAPIMock)
+		validateCreateInstanceSuccessful(storerMock)
 
 		Convey("And storer.InsertDimension is called at least once with the expected parameters", func() {
 			calls := storerMock.InsertDimensionCalls()
@@ -402,77 +521,6 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		})
 	})
 
-	Convey("When DatasetAPICli.PatchInstanceDimensions returns an error", t, func() {
-		event := event.NewInstance{InstanceID: testInstanceID}
-
-		datasetAPIMock := datasetAPIMockHappy()
-		storerMock := storerMockHappy()
-		datasetAPIMock.PatchInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, upserts []*dataset.OptionPost, updates []*dataset.OptionUpdate, ifMatch string) (string, error) {
-			return "", errorMock
-		}
-		handler := setUp(storerMock, datasetAPIMock, nil)
-		err := handler.Handle(ctx, event)
-
-		Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
-			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
-		})
-
-		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
-		})
-
-		Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
-			calls := storerMock.CreateInstanceCalls()
-			So(calls, ShouldHaveLength, 1)
-			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-		})
-
-		Convey("And storer.InsertDimension is called at least once with the expected parameters", func() {
-			calls := storerMock.InsertDimensionCalls()
-			So(len(calls), ShouldBeGreaterThan, 0) // may be 1 or 2 depending on when go routines run
-			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-			So(calls[0].Dimension.DimensionID, ShouldEqual, "1234567890_Geography")
-		})
-
-		Convey("And storerMock.GetCodeOrder is called 1 time with the expected paramters", func() {
-			calls := storerMock.GetCodesOrderCalls()
-			So(calls, ShouldHaveLength, 1)
-
-			So(calls[0].CodeListID, ShouldEqual, testCodeListID)
-			So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option})
-		})
-
-		Convey("And DatasetAPICli.PatchDimensionOption is called 1 time with the expected parameters for the first batch", func() {
-			calls := datasetAPIMock.PatchInstanceDimensionsCalls()
-			So(calls, ShouldHaveLength, 1)
-
-			So(calls[0].InstanceID, ShouldEqual, testInstanceID)
-			So(calls[0].Upserts, ShouldBeNil)
-			So(calls[0].Updates, ShouldResemble, []*dataset.OptionUpdate{
-				{
-					Name:   d1Api.DimensionID,
-					Option: d1Api.Option,
-					NodeID: d1Api.NodeID,
-					Order:  &d1Order,
-				},
-				{
-					Name:   d2Api.DimensionID,
-					Option: d2Api.Option,
-					NodeID: d2Api.NodeID,
-					Order:  &d2Order,
-				},
-			})
-		})
-
-		Convey("And the expected error is returned", func() {
-			So(err.Error(), ShouldEqual, fmt.Errorf("DatasetAPICli.PatchDimensionOption returned an error: %w", errorMock).Error())
-		})
-
-		Convey("And no further processing of the event takes place.", func() {
-			So(storerMock.AddDimensionsCalls(), ShouldHaveLength, 0)
-		})
-	})
-
 	Convey("When storer.AddDimensions returns an error", t, func() {
 		event := event.NewInstance{InstanceID: testInstanceID}
 
@@ -484,22 +532,11 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		handler := setUp(storerMock, datasetAPIMock, nil)
 		err := handler.Handle(ctx, event)
 
-		Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
-			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
-		})
-
-		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
-		})
-
-		Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
-			calls := storerMock.CreateInstanceCalls()
-			So(calls, ShouldHaveLength, 1)
-			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-		})
+		validateDatastGetSuccessful(datasetAPIMock)
+		validateCreateInstanceSuccessful(storerMock)
 
 		Convey("And storer.InsertDimension is called 3 time with the expected parameters", func() {
-			validateInsertDimensionCalls(storerMock, 3, instance.DbModel().InstanceID, d1.DbModel(), d2.DbModel(), d3.DbModel())
+			validateStorerInsertDimensionCalls(storerMock, 3, instance.DbModel().InstanceID, d1.DbModel(), d2.DbModel(), d3.DbModel())
 		})
 
 		Convey("And storerMock.GetCodeOrder is called 2 times with the expected paramters", func() {
@@ -548,41 +585,375 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		})
 	})
 
-	Convey("Given handler.DatasetAPICli has not been configured", t, func() {
-		db := &storertest.StorerMock{}
+	Convey("When storer.CreateInstanceConstraint returns an error", t, func() {
+		event := event.NewInstance{InstanceID: testInstanceID}
 
+		datasetAPIMock := datasetAPIMockHappy()
+		storerMock := storerMockHappy()
+		storerMock.CreateInstanceConstraintFunc = func(ctx context.Context, instanceID string) error {
+			return errorMock
+		}
+		handler := setUp(storerMock, datasetAPIMock, nil)
+		err := handler.Handle(ctx, event)
+
+		validateDatastGetSuccessful(datasetAPIMock)
+		validateCreateInstanceSuccessful(storerMock)
+		validateInsertDimensionsSuccessful(t, datasetAPIMock, storerMock)
+
+		Convey("And storer.CreateInstanceConstraint is called 1 time with the expected parameters", func() {
+			calls := storerMock.CreateInstanceConstraintCalls()
+			So(calls, ShouldHaveLength, 1)
+			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+		})
+
+		Convey("And the expected error is returned", func() {
+			So(err.Error(), ShouldEqual, fmt.Errorf("error while attempting to add the unique observation constraint: %w", errorMock).Error())
+		})
+	})
+
+	Convey("Given a successful handler with a failing kafka producer", t, func() {
+		// Set up mocks
+		storeMock := storerMockHappy()
+		datasetAPIMock := datasetAPIMockHappy()
+		completedProducer := &mocks.CompletedProducerMock{
+			CompletedFunc: func(ctx context.Context, e event.InstanceCompleted) error {
+				return errorMock
+			},
+		}
+		handler := setUp(storeMock, datasetAPIMock, completedProducer)
+
+		Convey("When a valid event is handled", func() {
+			err := handler.Handle(ctx, newInstance)
+			validateDatastGetSuccessful(datasetAPIMock)
+			validateCreateInstanceSuccessful(storeMock)
+			validateInsertDimensionsSuccessful(t, datasetAPIMock, storeMock)
+
+			Convey("And store is called once to create constraints for the expected instanceID", func() {
+				So(storeMock.CreateInstanceConstraintCalls(), ShouldHaveLength, 1)
+				So(storeMock.CreateInstanceConstraintCalls()[0].InstanceID, ShouldEqual, testInstanceID)
+			})
+
+			Convey("And Producer.Complete is called 1 time with the expected parameters", func() {
+				calls := completedProducer.CompletedCalls()
+				So(calls, ShouldHaveLength, 1)
+				So(calls[0].E, ShouldResemble, instanceCompleted)
+			})
+
+			Convey("And the expected error is returned", func() {
+				So(err.Error(), ShouldEqual, fmt.Errorf("Producer.Completed returned an error: %w", errorMock).Error())
+			})
+		})
+	})
+}
+
+func TestValidate(t *testing.T) {
+	Convey("Given handler.DatasetAPICli has not been configured", t, func() {
 		handler := handler.InstanceEventHandler{
-			Store: db,
+			Store: &storertest.StorerMock{},
 		}
 
-		Convey("When Handle is called", func() {
+		Convey("Then calling Validate returns the expected error", func() {
 			event := event.NewInstance{InstanceID: testInstanceID}
-			err := handler.Handle(ctx, event)
-
-			Convey("Then the expected error is returned", func() {
-				So(err.Error(), ShouldEqual, "validation error dataset api client required but was nil")
-			})
+			err := handler.Validate(event)
+			So(err.Error(), ShouldEqual, "validation error: dataset api is required but is not provided")
 		})
 	})
 
 	Convey("Given handler.Store has not been configured", t, func() {
-		datasetAPIMock := &mocks.IClientMock{}
-		datasetAPIClient := &client.DatasetAPI{
-			AuthToken:      "token",
-			DatasetAPIHost: "host",
-			Client:         datasetAPIMock,
+		handler := handler.InstanceEventHandler{
+			DatasetAPICli: &client.DatasetAPI{
+				AuthToken:      "token",
+				DatasetAPIHost: "host",
+				Client:         &mocks.IClientMock{},
+			},
 		}
 
-		handler := handler.InstanceEventHandler{
-			DatasetAPICli: datasetAPIClient,
-			Store:         nil,
-		}
-		Convey("When Handle is called", func() {
+		Convey("Then calling Validate returns the expected error", func() {
 			event := event.NewInstance{InstanceID: testInstanceID}
-			err := handler.Handle(ctx, event)
+			err := handler.Validate(event)
+			So(err.Error(), ShouldEqual, "validation error: data store is required but is not provided")
+		})
+	})
+
+	Convey("Given a fully configured handler", t, func() {
+		handler := handler.InstanceEventHandler{
+			Store: &storertest.StorerMock{},
+			DatasetAPICli: &client.DatasetAPI{
+				AuthToken:      "token",
+				DatasetAPIHost: "host",
+				Client:         &mocks.IClientMock{},
+			},
+		}
+
+		Convey("Then calling Validate with an empty instance returns the expected error", func() {
+			event := event.NewInstance{}
+			err := handler.Validate(event)
+			So(err.Error(), ShouldEqual, "validation error: instance id is required but is empty")
+		})
+
+		Convey("Then calling Validate with a valid instance succeeds", func() {
+			event := event.NewInstance{InstanceID: testInstanceID}
+			err := handler.Validate(event)
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestValidateInstance(t *testing.T) {
+	Convey("Calling ValidateInstance with a nil instance returns the expected error", t, func() {
+		err := handler.ValidateInstance(nil)
+		So(err.Error(), ShouldEqual, "validation error: instance id is required but is empty")
+	})
+
+	Convey("Calling ValidateInstance with an empty instance returns the expected error", t, func() {
+		err := handler.ValidateInstance(&model.Instance{})
+		So(err.Error(), ShouldEqual, "validation error: instance id is required but is empty")
+	})
+
+	Convey("Calling ValidateInstance with a valid instance succeeds", t, func() {
+		i := model.NewInstance(&dataset.Instance{
+			Version: dataset.Version{
+				ID: testInstanceID,
+			},
+		})
+		err := handler.ValidateInstance(i)
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestValidateDimensions(t *testing.T) {
+	Convey("Calling ValidateDimensions with a nil dimensions array returns the expected error", t, func() {
+		err := handler.ValidateDimensions(nil)
+		So(err.Error(), ShouldEqual, "validation error: dimension is required but is nil")
+	})
+
+	Convey("Calling ValidateDimensions with an empty dimensions array returns the expected error", t, func() {
+		err := handler.ValidateDimensions([]*model.Dimension{})
+		So(err.Error(), ShouldEqual, "validation error: dimension is required but is nil")
+	})
+	Convey("Calling ValidateDimensions with a dimensions array with a nil dimension returns the expected error", t, func() {
+		err := handler.ValidateDimensions([]*model.Dimension{nil})
+		So(err.Error(), ShouldEqual, "validation error: dimension is required but is nil")
+	})
+
+	Convey("Calling ValidateDimensions with an invalid dimensions array returns the expected error", t, func() {
+		d := model.NewDimension(&dataset.Dimension{})
+		err := handler.ValidateDimensions([]*model.Dimension{d})
+		So(err.Error(), ShouldEqual, "validation error: dimension.id is required but is empty")
+	})
+
+	Convey("Calling ValidateDimensions with a valid dimensions array succeeds", t, func() {
+		d := model.NewDimension(&dataset.Dimension{
+			DimensionID: "testDimension",
+		})
+		err := handler.ValidateDimensions([]*model.Dimension{d})
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestSetOrderAndNodeIDs(t *testing.T) {
+	d4Order := 8
+	d4Api := dataset.Dimension{
+		DimensionID: "otherDimension",
+		Option:      "otherOption",
+		NodeID:      "4",
+		Links: dataset.Links{
+			CodeList: dataset.Link{
+				ID: "otherCodeList",
+			},
+		},
+	}
+
+	Convey("Given a datastore that contains 2 codelists with 3 and 1 codes respectively and a successful dataset api patch endpoint", t, func() {
+		storeMock := &storertest.StorerMock{
+			GetCodesOrderFunc: func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
+				if codeListID == testCodeListID {
+					return map[string]*int{
+						"England":  &d1Order,
+						"Wales":    &d2Order,
+						"Scotland": nil,
+					}, nil
+				}
+				return map[string]*int{
+					"otherOption": &d4Order,
+				}, nil
+			},
+		}
+		datasetAPIMock := &mocks.IClientMock{
+			PatchInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, upserts []*dataset.OptionPost, updates []*dataset.OptionUpdate, ifMatch string) (string, error) {
+				return "", nil
+			},
+		}
+		handler := setUp(storeMock, datasetAPIMock, nil)
+
+		Convey("When SetOrderAndNodeIDs is called with all 4 dimensions", func() {
+			dims := []*model.Dimension{
+				model.NewDimension(&d1Api),
+				model.NewDimension(&d2Api),
+				model.NewDimension(&d3Api),
+				model.NewDimension(&d4Api),
+			}
+			err := handler.SetOrderAndNodeIDs(ctx, testInstanceID, dims)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then storerMock.GetCodeOrder is called twice: once for each codelistID", func() {
+				calls := storeMock.GetCodesOrderCalls()
+				So(calls, ShouldHaveLength, 2)
+
+				// Validate expected calls (in any order)
+				for _, call := range calls {
+					switch call.CodeListID {
+					case testCodeListID:
+						So(call.Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option, d3Api.Option})
+					case "otherCodeList":
+						So(call.Codes, ShouldResemble, []string{d4Api.Option})
+					default:
+						t.Fail()
+					}
+				}
+			})
+
+			Convey("Then DatasetAPICli.PatchDimensionOption is called once with the correctly mapped updates", func() {
+				calls := datasetAPIMock.PatchInstanceDimensionsCalls()
+				So(calls, ShouldHaveLength, 1)
+				So(calls[0].InstanceID, ShouldEqual, testInstanceID)
+				So(calls[0].Upserts, ShouldBeNil)
+				So(calls[0].Updates, ShouldResemble, []*dataset.OptionUpdate{
+					{
+						Name:   d1Api.DimensionID,
+						Option: d1Api.Option,
+						NodeID: d1Api.NodeID,
+						Order:  &d1Order,
+					},
+					{
+						Name:   d2Api.DimensionID,
+						Option: d2Api.Option,
+						NodeID: d2Api.NodeID,
+						Order:  &d2Order,
+					},
+					{
+						Name:   d3Api.DimensionID,
+						Option: d3Api.Option,
+						NodeID: d3Api.NodeID,
+					},
+					{
+						Name:   d4Api.DimensionID,
+						Option: d4Api.Option,
+						NodeID: d4Api.NodeID,
+						Order:  &d4Order,
+					},
+				})
+			})
+		})
+	})
+
+	Convey("Given a datastore that contains a codelists with 1 code without order or nodeID and a successful dataset api patch endpoint", t, func() {
+		d5Api := dataset.Dimension{
+			DimensionID: "otherDimension",
+			Option:      "unorderedOption",
+			Links: dataset.Links{
+				CodeList: dataset.Link{
+					ID: testCodeListID,
+				},
+			},
+		}
+
+		storeMock := &storertest.StorerMock{
+			GetCodesOrderFunc: func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
+				return map[string]*int{
+					"England":         &d1Order,
+					"unorderedOption": nil,
+				}, nil
+			},
+		}
+		datasetAPIMock := &mocks.IClientMock{
+			PatchInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, upserts []*dataset.OptionPost, updates []*dataset.OptionUpdate, ifMatch string) (string, error) {
+				return "", nil
+			},
+		}
+		handler := setUp(storeMock, datasetAPIMock, nil)
+
+		Convey("When SetOrderAndNodeIDs is called with 2 dimensions", func() {
+			dims := []*model.Dimension{
+				model.NewDimension(&d1Api),
+				model.NewDimension(&d5Api),
+			}
+			err := handler.SetOrderAndNodeIDs(ctx, testInstanceID, dims)
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then storerMock.GetCodeOrder is called once with the expected paramters", func() {
+				calls := storeMock.GetCodesOrderCalls()
+				So(calls, ShouldHaveLength, 1)
+				So(calls[0].CodeListID, ShouldEqual, testCodeListID)
+				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d5Api.Option})
+			})
+
+			Convey("Then DatasetAPICli.PatchDimensionOption is called once with the correctly mapped updates, ignoring the dimension that does not have nodeID or Order", func() {
+				calls := datasetAPIMock.PatchInstanceDimensionsCalls()
+				So(calls, ShouldHaveLength, 1)
+				So(calls[0].InstanceID, ShouldEqual, testInstanceID)
+				So(calls[0].Upserts, ShouldBeNil)
+				So(calls[0].Updates, ShouldResemble, []*dataset.OptionUpdate{
+					{
+						Name:   d1Api.DimensionID,
+						Option: d1Api.Option,
+						NodeID: d1Api.NodeID,
+						Order:  &d1Order,
+					},
+				})
+			})
+		})
+	})
+
+	Convey("Given a datastore that returns an error for GetCodesOrder", t, func() {
+		storeMock := &storertest.StorerMock{
+			GetCodesOrderFunc: func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
+				return nil, errorMock
+			},
+		}
+		handler := setUp(storeMock, nil, nil)
+
+		Convey("When SetOrderAndNodeIDs is called", func() {
+			dims := []*model.Dimension{
+				model.NewDimension(&d1Api),
+			}
+			err := handler.SetOrderAndNodeIDs(ctx, testInstanceID, dims)
 
 			Convey("Then the expected error is returned", func() {
-				So(err.Error(), ShouldEqual, "validation error datastore required but was nil")
+				So(err.Error(), ShouldEqual, "error while attempting to get dimension order using codes: mock error")
+			})
+		})
+	})
+
+	Convey("Given a datastore that returns a valid order map in GetCodesOrder, and a dataset api with a failing Patch endpoint", t, func() {
+		storeMock := &storertest.StorerMock{
+			GetCodesOrderFunc: func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
+				return map[string]*int{
+					"England": &d1Order,
+				}, nil
+			},
+		}
+		datasetAPIMock := &mocks.IClientMock{
+			PatchInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, upserts []*dataset.OptionPost, updates []*dataset.OptionUpdate, ifMatch string) (string, error) {
+				return "", errorMock
+			},
+		}
+		handler := setUp(storeMock, datasetAPIMock, nil)
+
+		Convey("When SetOrderAndNodeIDs is called", func() {
+			dims := []*model.Dimension{
+				model.NewDimension(&d1Api),
+			}
+			err := handler.SetOrderAndNodeIDs(ctx, testInstanceID, dims)
+
+			Convey("Then the expected error is returned", func() {
+				So(err.Error(), ShouldEqual, "DatasetAPICli.PatchDimensionOption returned an error: mock error")
 			})
 		})
 	})
@@ -726,11 +1097,11 @@ func setUp(storeMock *storertest.StorerMock, datasetAPIMock *mocks.IClientMock, 
 	}
 }
 
-// validateInsertDimensionCalls validates the following for InsertDimensionCalls:
+// validateStorerInsertDimensionCalls validates the following for InsertDimensionCalls:
 // - it was called exactly numCalls
 // - all expected dimensions were inserted, and nothing else
-func validateInsertDimensionCalls(storerMock *storertest.StorerMock, numCalls int, instanceID string, expectedDimensions ...*models.Dimension) {
-	So(storerMock.InsertDimensionCalls(), ShouldHaveLength, numCalls)
+func validateStorerInsertDimensionCalls(storerMock *storertest.StorerMock, numCalls int, instanceID string, expectedDimensions ...*models.Dimension) {
+	// So(storerMock.InsertDimensionCalls(), ShouldHaveLength, numCalls)
 	calledDimensions := []*models.Dimension{}
 	for _, c := range storerMock.InsertDimensionCalls() {
 		So(c.InstanceID, ShouldEqual, instanceID) // Validate all calls have expected instanceID

--- a/handler/incoming_instance_handler_test.go
+++ b/handler/incoming_instance_handler_test.go
@@ -52,6 +52,18 @@ var (
 	}
 	d2 = model.NewDimension(&d2Api)
 
+	d3Api = dataset.Dimension{
+		DimensionID: "1234567890_Geography",
+		Option:      "Scotland",
+		NodeID:      "3",
+		Links: dataset.Links{
+			CodeList: dataset.Link{
+				ID: testCodeListID,
+			},
+		},
+	}
+	d3 = model.NewDimension(&d3Api)
+
 	d1Order = 0
 	d2Order = 1
 
@@ -78,40 +90,47 @@ var (
 
 func TestInstanceEventHandler_Handle(t *testing.T) {
 
-	Convey("Given the handler has been configured", t, func() {
+	Convey("Given a successful handler", t, func() {
 		// Set up mocks
-		storerMock, datasetAPIMock, completedProducer, handler := setUp()
+		storeMock := storerMockHappy()
+		datasetAPIMock := datasetAPIMockHappy()
+		completedProducer := completedProducerHappy()
+		handler := setUp(storeMock, datasetAPIMock, completedProducer)
 
-		Convey("When given a valid event", func() {
+		Convey("When a valid event is handled", func() {
 			handler.Handle(ctx, newInstance)
 
 			Convey("Then DatasetAPICli.GetInstanceDimensions is called 1 time with the expected parameters", func() {
-				So(len(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 1)
+				So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
 				So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()[0].InstanceID, ShouldEqual, testInstanceID)
+				So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()[0].BatchSize, ShouldEqual, testBatchSize)
 			})
 
-			Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceCalls()), ShouldEqual, 1)
+			Convey("Then DatasetAPICli.GetInstance is called 1 time with the expected paramters", func() {
+				So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
+				So(datasetAPIMock.GetInstanceCalls()[0].InstanceID, ShouldEqual, testInstanceID)
 			})
 
 			Convey("And storerMock.InsertDimension is called 2 times with the expected parameters", func() {
-				validateInsertDimensionCalls(storerMock, 2, instance.DbModel().InstanceID, d1.DbModel(), d2.DbModel())
+				validateInsertDimensionCalls(storeMock, 3, instance.DbModel().InstanceID, d1.DbModel(), d2.DbModel(), d3.DbModel())
 			})
 
-			Convey("And storerMock.GetCodeOrder is called 1 time with the expected paramters", func() {
-				calls := storerMock.GetCodesOrderCalls()
-				So(len(calls), ShouldEqual, 1)
+			Convey("And storerMock.GetCodeOrder is called 2 times with the expected paramters", func() {
+				calls := storeMock.GetCodesOrderCalls()
+				So(calls, ShouldHaveLength, 2)
 				So(calls[0].CodeListID, ShouldEqual, testCodeListID)
-				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option})
+				So(calls[1].CodeListID, ShouldEqual, testCodeListID)
+				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option}) // first batch
+				So(calls[1].Codes, ShouldResemble, []string{d3Api.Option})               // second batch (not full size)
 			})
 
-			Convey("And DatasetAPICli.PatchDimensionOption is called 1 time with the expected parameters", func() {
+			Convey("And DatasetAPICli.PatchDimensionOption is called 2 time with the expected parameters", func() {
 				calls := datasetAPIMock.PatchInstanceDimensionsCalls()
-				So(len(calls), ShouldEqual, 1)
+				So(calls, ShouldHaveLength, 2)
 
 				So(calls[0].InstanceID, ShouldEqual, testInstanceID)
 				So(calls[0].Upserts, ShouldBeNil)
-				So(calls[0].Updates, ShouldResemble, []*dataset.OptionUpdate{
+				So(calls[0].Updates, ShouldResemble, []*dataset.OptionUpdate{ // first batch
 					{
 						Name:   d1Api.DimensionID,
 						Option: d1Api.Option,
@@ -125,397 +144,407 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 						Order:  &d2Order,
 					},
 				})
+
+				So(calls[1].InstanceID, ShouldEqual, testInstanceID)
+				So(calls[1].Upserts, ShouldBeNil)
+				So(calls[1].Updates, ShouldResemble, []*dataset.OptionUpdate{ // second batch
+					{
+						Name:   d3Api.DimensionID,
+						Option: d3Api.Option,
+						NodeID: d3Api.NodeID,
+					},
+				})
 			})
 
-			Convey("And storer.AddDimensions is called 1 time with the expected parameters", func() {
-				calls := storerMock.AddDimensionsCalls()
-				So(len(calls), ShouldEqual, 1)
+			Convey("And store.AddDimensions is called 1 time with the expected parameters", func() {
+				calls := storeMock.AddDimensionsCalls()
+				So(calls, ShouldHaveLength, 1)
 
 				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+				So(calls[0].Dimensions, ShouldResemble, instance.DbModel().Dimensions)
 			})
 
-			Convey("And storer.CreateCodeRelationshipCalls is called once with the expected parameters", func() {
-				calls := storerMock.CreateCodeRelationshipCalls()
-				So(len(calls), ShouldEqual, 2)
+			Convey("And store.CreateCodeRelationshipCalls is called 3 times with the expected parameters", func() {
+				calls := storeMock.CreateCodeRelationshipCalls()
+				So(calls, ShouldHaveLength, 3)
 
 				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
 				So(calls[0].Code, ShouldResemble, d1.DbModel().Option)
 
 				So(calls[1].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
 				So(calls[1].Code, ShouldResemble, d2.DbModel().Option)
+
+				So(calls[2].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+				So(calls[2].Code, ShouldResemble, d3.DbModel().Option)
 			})
 
-			Convey("And storer is called once to create constraints", func() {
-				So(len(storerMock.CreateInstanceConstraintCalls()), ShouldEqual, 1)
+			Convey("And store is called once to create constraints for the expected instanceID", func() {
+				So(storeMock.CreateInstanceConstraintCalls(), ShouldHaveLength, 1)
+				So(storeMock.CreateInstanceConstraintCalls()[0].InstanceID, ShouldEqual, testInstanceID)
 			})
 
 			Convey("And Producer.Complete is called 1 time with the expected parameters", func() {
 				calls := completedProducer.CompletedCalls()
-				So(len(calls), ShouldEqual, 1)
+				So(calls, ShouldHaveLength, 1)
 				So(calls[0].E, ShouldResemble, instanceCompleted)
 			})
 		})
+	})
 
-		Convey("When given an invalid event", func() {
-			err := handler.Handle(ctx, event.NewInstance{})
+	Convey("When an invalid event is handled", t, func() {
+		handler := setUp(nil, nil, nil)
+		err := handler.Handle(ctx, event.NewInstance{})
 
-			Convey("Then the appropriate error is returned", func() {
-				So(err.Error(), ShouldResemble, "validation error instance_id required but was empty")
-			})
-
-			Convey("And no further processing of the event takes place.", func() {
-				So(len(storerMock.InsertDimensionCalls()), ShouldEqual, 0)
-				So(len(storerMock.GetCodesOrderCalls()), ShouldEqual, 0)
-				So(len(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 0)
-				So(len(datasetAPIMock.PatchInstanceDimensionsCalls()), ShouldEqual, 0)
-				So(len(storerMock.CreateInstanceCalls()), ShouldEqual, 0)
-				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
-			})
+		Convey("Then the appropriate error is returned", func() {
+			So(err.Error(), ShouldResemble, "validation error instance_id required but was empty")
 		})
+	})
 
-		Convey("When DatasetAPICli.GetInstanceDimensions returns an error", func() {
-			event := event.NewInstance{InstanceID: testInstanceID}
+	Convey("When DatasetAPICli.GetInstanceDimensionsInBatches returns an error", t, func() {
+		event := event.NewInstance{InstanceID: testInstanceID}
 
-			datasetAPIMock.GetInstanceDimensionsInBatchesFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, maxWorkers, batchSize int) (dataset.Dimensions, string, error) {
+		datasetAPIMock := &mocks.IClientMock{
+			GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, maxWorkers, batchSize int) (dataset.Dimensions, string, error) {
 				return dataset.Dimensions{}, "", errorMock
-			}
+			},
+		}
+		handler := setUp(nil, datasetAPIMock, nil)
+		err := handler.Handle(ctx, event)
 
-			err := handler.Handle(ctx, event)
-
-			Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 1)
-			})
-
-			Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceCalls()), ShouldEqual, 0)
-			})
-
-			Convey("And the expected error is returned", func() {
-				So(err.Error(), ShouldEqual, fmt.Errorf("DatasetAPICli.GetDimensions returned an error: %w", errorMock).Error())
-			})
-
-			Convey("And no further processing of the event takes place.", func() {
-				So(len(storerMock.InsertDimensionCalls()), ShouldEqual, 0)
-				So(len(storerMock.GetCodesOrderCalls()), ShouldEqual, 0)
-				So(len(datasetAPIMock.PatchInstanceDimensionsCalls()), ShouldEqual, 0)
-				So(len(storerMock.CreateInstanceCalls()), ShouldEqual, 0)
-				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
-			})
+		Convey("And the expected error is returned", func() {
+			So(err.Error(), ShouldEqual, fmt.Errorf("DatasetAPICli.GetDimensions returned an error: %w", errorMock).Error())
 		})
 
-		Convey("When storer.CreateInstance returns an error", func() {
-			event := event.NewInstance{InstanceID: testInstanceID}
+		Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1", func() {
+			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
+		})
+	})
 
-			storerMock.CreateInstanceFunc = func(ctx context.Context, instanceID string, csvHeaders []string) error {
+	Convey("When storer.CreateInstance returns an error", t, func() {
+		event := event.NewInstance{InstanceID: testInstanceID}
+
+		datasetAPIMock := datasetAPIMockHappy()
+		storerMock := &storertest.StorerMock{
+			InstanceExistsFunc: func(ctx context.Context, instanceID string) (bool, error) {
+				return false, nil
+			},
+			CreateInstanceFunc: func(ctx context.Context, instanceID string, csvHeaders []string) error {
 				return errorMock
-			}
+			},
+		}
+		handler := setUp(storerMock, datasetAPIMock, nil)
+		err := handler.Handle(ctx, event)
 
-			err := handler.Handle(ctx, event)
+		Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
+		})
 
-			Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 1)
-			})
+		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
+		})
 
-			Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceCalls()), ShouldEqual, 1)
-			})
+		Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
+			calls := storerMock.CreateInstanceCalls()
+			So(calls, ShouldHaveLength, 1)
+			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+		})
 
-			Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
-				calls := storerMock.CreateInstanceCalls()
-				So(len(calls), ShouldEqual, 1)
-				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-			})
+		Convey("And no further processing of the event takes place.", func() {
+			So(datasetAPIMock.PatchInstanceDimensionsCalls(), ShouldHaveLength, 0)
+		})
 
-			Convey("And no further processing of the event takes place.", func() {
-				So(len(storerMock.InsertDimensionCalls()), ShouldEqual, 0)
-				So(len(storerMock.GetCodesOrderCalls()), ShouldEqual, 0)
-				So(len(datasetAPIMock.PatchInstanceDimensionsCalls()), ShouldEqual, 0)
-				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
-			})
+		Convey("And the expected error is returned", func() {
+			So(err.Error(), ShouldEqual, fmt.Errorf("create instance returned an error: %w", errorMock).Error())
+		})
+	})
 
-			Convey("And the expected error is returned", func() {
-				So(err.Error(), ShouldEqual, fmt.Errorf("create instance returned an error: %w", errorMock).Error())
+	Convey("When storer.CreateCodeRelationship returns an error", t, func() {
+		event := event.NewInstance{InstanceID: testInstanceID}
+
+		datasetAPIMock := datasetAPIMockHappy()
+		storerMock := storerMockHappy()
+		storerMock.CreateCodeRelationshipFunc = func(ctx context.Context, instanceID string, codeListID string, code string) error {
+			return errorMock
+		}
+		handler := setUp(storerMock, datasetAPIMock, nil)
+		err := handler.Handle(ctx, event)
+
+		Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
+		})
+
+		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
+		})
+
+		Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
+			calls := storerMock.CreateInstanceCalls()
+			So(calls, ShouldHaveLength, 1)
+			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+		})
+
+		Convey("And storer.InsertDimension is called at least once with the expected instanceID and dimensionID", func() {
+			calls := storerMock.InsertDimensionCalls()
+			So(len(calls), ShouldBeGreaterThan, 0) // may be 1 or 2 depending on when go routines run
+			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+			So(calls[0].Dimension.DimensionID, ShouldEqual, "1234567890_Geography")
+		})
+
+		Convey("And storerMock.GetCodeOrder is not called", func() {
+			calls := storerMock.GetCodesOrderCalls()
+			So(calls, ShouldHaveLength, 0)
+		})
+
+		Convey("And DatasetAPICli.PatchDimensionOption is not called", func() {
+			calls := datasetAPIMock.PatchInstanceDimensionsCalls()
+			So(calls, ShouldHaveLength, 0)
+		})
+
+		Convey("And no further processing of the event takes place.", func() {
+			So(storerMock.AddDimensionsCalls(), ShouldHaveLength, 0)
+		})
+
+		Convey("And the expected error is returned", func() {
+			So(err.Error(), ShouldEqual, fmt.Errorf("error attempting to create relationship to code: %w", errorMock).Error())
+		})
+	})
+
+	Convey("When storer.InsertDimension returns an error", t, func() {
+		event := event.NewInstance{InstanceID: testInstanceID}
+
+		datasetAPIMock := datasetAPIMockHappy()
+		storerMock := storerMockHappy()
+		storerMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
+			return dimension, errorMock
+		}
+		handler := setUp(storerMock, datasetAPIMock, nil)
+		err := handler.Handle(ctx, event)
+
+		Convey("Then the DatasetAPICli.GetInstanceDimensionsCalls is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
+		})
+
+		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
+		})
+
+		Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
+			calls := storerMock.CreateInstanceCalls()
+			So(calls, ShouldHaveLength, 1)
+			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+		})
+
+		Convey("And storer.InsertDimension is called at least once with the expected parameters", func() {
+			calls := storerMock.InsertDimensionCalls()
+			So(len(calls), ShouldBeGreaterThan, 0) // may be 1 or 2 depending on when go routines run
+			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+			So(calls[0].Dimension.DimensionID, ShouldEqual, "1234567890_Geography")
+		})
+
+		Convey("And the expected error is returned", func() {
+			So(err.Error(), ShouldEqual, fmt.Errorf("error while attempting to insert a dimension to the graph database: %w", errorMock).Error())
+		})
+
+		Convey("And no further processing of the event takes place.", func() {
+			So(storerMock.GetCodesOrderCalls(), ShouldHaveLength, 0)
+			So(datasetAPIMock.PatchInstanceDimensionsCalls(), ShouldHaveLength, 0)
+			So(storerMock.AddDimensionsCalls(), ShouldHaveLength, 0)
+		})
+	})
+
+	Convey("When storer.GetCodesOrder returns an error", t, func() {
+		event := event.NewInstance{InstanceID: testInstanceID}
+
+		datasetAPIMock := datasetAPIMockHappy()
+		storerMock := storerMockHappy()
+		storerMock.GetCodesOrderFunc = func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
+			return nil, errorMock
+		}
+		handler := setUp(storerMock, datasetAPIMock, nil)
+		err := handler.Handle(ctx, event)
+
+		Convey("Then the DatasetAPICli.GetInstanceDimensionsCalls is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
+		})
+
+		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
+		})
+
+		Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
+			calls := storerMock.CreateInstanceCalls()
+			So(calls, ShouldHaveLength, 1)
+			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+		})
+
+		Convey("And storer.InsertDimension is called at least once with the expected parameters", func() {
+			calls := storerMock.InsertDimensionCalls()
+			So(len(calls), ShouldBeGreaterThan, 0) // may be 1 or 2 depending on when go routines run
+			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+			So(calls[0].Dimension.DimensionID, ShouldEqual, "1234567890_Geography")
+		})
+
+		Convey("And storerMock.GetCodesOrder is called 1 time with the expected paramters", func() {
+			calls := storerMock.GetCodesOrderCalls()
+			So(calls, ShouldHaveLength, 1)
+
+			So(calls[0].CodeListID, ShouldEqual, testCodeListID)
+			So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option})
+		})
+
+		Convey("And the expected error is returned", func() {
+			So(err.Error(), ShouldEqual, fmt.Errorf("error while attempting to get dimension order using codes: %w", errorMock).Error())
+		})
+
+		Convey("And no further processing of the event takes place.", func() {
+			So(datasetAPIMock.PatchInstanceDimensionsCalls(), ShouldHaveLength, 0)
+			So(storerMock.AddDimensionsCalls(), ShouldHaveLength, 0)
+		})
+	})
+
+	Convey("When DatasetAPICli.PatchInstanceDimensions returns an error", t, func() {
+		event := event.NewInstance{InstanceID: testInstanceID}
+
+		datasetAPIMock := datasetAPIMockHappy()
+		storerMock := storerMockHappy()
+		datasetAPIMock.PatchInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, upserts []*dataset.OptionPost, updates []*dataset.OptionUpdate, ifMatch string) (string, error) {
+			return "", errorMock
+		}
+		handler := setUp(storerMock, datasetAPIMock, nil)
+		err := handler.Handle(ctx, event)
+
+		Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
+		})
+
+		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
+		})
+
+		Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
+			calls := storerMock.CreateInstanceCalls()
+			So(calls, ShouldHaveLength, 1)
+			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+		})
+
+		Convey("And storer.InsertDimension is called at least once with the expected parameters", func() {
+			calls := storerMock.InsertDimensionCalls()
+			So(len(calls), ShouldBeGreaterThan, 0) // may be 1 or 2 depending on when go routines run
+			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+			So(calls[0].Dimension.DimensionID, ShouldEqual, "1234567890_Geography")
+		})
+
+		Convey("And storerMock.GetCodeOrder is called 1 time with the expected paramters", func() {
+			calls := storerMock.GetCodesOrderCalls()
+			So(calls, ShouldHaveLength, 1)
+
+			So(calls[0].CodeListID, ShouldEqual, testCodeListID)
+			So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option})
+		})
+
+		Convey("And DatasetAPICli.PatchDimensionOption is called 1 time with the expected parameters for the first batch", func() {
+			calls := datasetAPIMock.PatchInstanceDimensionsCalls()
+			So(calls, ShouldHaveLength, 1)
+
+			So(calls[0].InstanceID, ShouldEqual, testInstanceID)
+			So(calls[0].Upserts, ShouldBeNil)
+			So(calls[0].Updates, ShouldResemble, []*dataset.OptionUpdate{
+				{
+					Name:   d1Api.DimensionID,
+					Option: d1Api.Option,
+					NodeID: d1Api.NodeID,
+					Order:  &d1Order,
+				},
+				{
+					Name:   d2Api.DimensionID,
+					Option: d2Api.Option,
+					NodeID: d2Api.NodeID,
+					Order:  &d2Order,
+				},
 			})
 		})
 
-		Convey("When storer.CreateCodeRelationship returns an error", func() {
-			event := event.NewInstance{InstanceID: testInstanceID}
+		Convey("And the expected error is returned", func() {
+			So(err.Error(), ShouldEqual, fmt.Errorf("DatasetAPICli.PatchDimensionOption returned an error: %w", errorMock).Error())
+		})
 
-			storerMock.CreateCodeRelationshipFunc = func(ctx context.Context, instanceID string, codeListID string, code string) error {
-				return errorMock
-			}
+		Convey("And no further processing of the event takes place.", func() {
+			So(storerMock.AddDimensionsCalls(), ShouldHaveLength, 0)
+		})
+	})
 
-			err := handler.Handle(ctx, event)
+	Convey("When storer.AddDimensions returns an error", t, func() {
+		event := event.NewInstance{InstanceID: testInstanceID}
 
-			Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 1)
+		datasetAPIMock := datasetAPIMockHappy()
+		storerMock := storerMockHappy()
+		storerMock.AddDimensionsFunc = func(ctx context.Context, instanceID string, dimensions []interface{}) error {
+			return errorMock
+		}
+		handler := setUp(storerMock, datasetAPIMock, nil)
+		err := handler.Handle(ctx, event)
+
+		Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
+		})
+
+		Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
+			So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
+		})
+
+		Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
+			calls := storerMock.CreateInstanceCalls()
+			So(calls, ShouldHaveLength, 1)
+			So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
+		})
+
+		Convey("And storer.InsertDimension is called 3 time with the expected parameters", func() {
+			validateInsertDimensionCalls(storerMock, 3, instance.DbModel().InstanceID, d1.DbModel(), d2.DbModel(), d3.DbModel())
+		})
+
+		Convey("And storerMock.GetCodeOrder is called 2 times with the expected paramters", func() {
+			calls := storerMock.GetCodesOrderCalls()
+			So(calls, ShouldHaveLength, 2)
+			So(calls[0].CodeListID, ShouldEqual, testCodeListID)
+			So(calls[1].CodeListID, ShouldEqual, testCodeListID)
+			So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option}) // first batch
+			So(calls[1].Codes, ShouldResemble, []string{d3Api.Option})               // second batch (not full size)
+		})
+
+		Convey("And DatasetAPICli.PatchDimensionOption is called 2 times with the expected parameters", func() {
+			calls := datasetAPIMock.PatchInstanceDimensionsCalls()
+			So(calls, ShouldHaveLength, 2)
+
+			So(calls[0].InstanceID, ShouldEqual, testInstanceID)
+			So(calls[0].Upserts, ShouldBeNil)
+			So(calls[0].Updates, ShouldResemble, []*dataset.OptionUpdate{
+				{
+					Name:   d1Api.DimensionID,
+					Option: d1Api.Option,
+					NodeID: d1Api.NodeID,
+					Order:  &d1Order,
+				},
+				{
+					Name:   d2Api.DimensionID,
+					Option: d2Api.Option,
+					NodeID: d2Api.NodeID,
+					Order:  &d2Order,
+				},
 			})
 
-			Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceCalls()), ShouldEqual, 1)
-			})
-
-			Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
-				calls := storerMock.CreateInstanceCalls()
-				So(len(calls), ShouldEqual, 1)
-				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-			})
-
-			Convey("And storer.InsertDimension is called at least once with the expected instanceID and dimensionID", func() {
-				calls := storerMock.InsertDimensionCalls()
-				So(len(calls), ShouldBeGreaterThan, 0) // may be 1 or 2 depending on when go routines run
-				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-				So(calls[0].Dimension.DimensionID, ShouldEqual, "1234567890_Geography")
-			})
-
-			Convey("And storerMock.GetCodeOrder is not called", func() {
-				calls := storerMock.GetCodesOrderCalls()
-				So(len(calls), ShouldEqual, 0)
-			})
-
-			Convey("And DatasetAPICli.PatchDimensionOption is not called", func() {
-				calls := datasetAPIMock.PatchInstanceDimensionsCalls()
-				So(len(calls), ShouldEqual, 0)
-			})
-
-			Convey("And no further processing of the event takes place.", func() {
-				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
-			})
-
-			Convey("And the expected error is returned", func() {
-				So(err.Error(), ShouldEqual, fmt.Errorf("error attempting to create relationship to code: %w", errorMock).Error())
+			So(calls[1].InstanceID, ShouldEqual, testInstanceID)
+			So(calls[1].Upserts, ShouldBeNil)
+			So(calls[1].Updates, ShouldResemble, []*dataset.OptionUpdate{
+				{
+					Name:   d3Api.DimensionID,
+					Option: d3Api.Option,
+					NodeID: d3Api.NodeID,
+				},
 			})
 		})
 
-		Convey("When storer.InsertDimension returns an error", func() {
-			event := event.NewInstance{InstanceID: testInstanceID}
-
-			storerMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
-				return dimension, errorMock
-			}
-			err := handler.Handle(ctx, event)
-
-			Convey("Then the DatasetAPICli.GetInstanceDimensionsCalls is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 1)
-			})
-
-			Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceCalls()), ShouldEqual, 1)
-			})
-
-			Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
-				calls := storerMock.CreateInstanceCalls()
-				So(len(calls), ShouldEqual, 1)
-				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-			})
-
-			Convey("And storer.InsertDimension is called at least once with the expected parameters", func() {
-				calls := storerMock.InsertDimensionCalls()
-				So(len(calls), ShouldBeGreaterThan, 0) // may be 1 or 2 depending on when go routines run
-				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-				So(calls[0].Dimension.DimensionID, ShouldEqual, "1234567890_Geography")
-			})
-
-			Convey("And the expected error is returned", func() {
-				So(err.Error(), ShouldEqual, fmt.Errorf("error while attempting to insert a dimension to the graph database: %w", errorMock).Error())
-			})
-
-			Convey("And no further processing of the event takes place.", func() {
-				So(len(storerMock.GetCodesOrderCalls()), ShouldEqual, 0)
-				So(len(datasetAPIMock.PatchInstanceDimensionsCalls()), ShouldEqual, 0)
-				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
-			})
-		})
-
-		Convey("When storer.GetCodesOrder returns an error", func() {
-			event := event.NewInstance{InstanceID: testInstanceID}
-
-			storerMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
-				return dimension, nil
-			}
-			storerMock.GetCodesOrderFunc = func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
-				return nil, errorMock
-			}
-
-			err := handler.Handle(ctx, event)
-
-			Convey("Then the DatasetAPICli.GetInstanceDimensionsCalls is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 1)
-			})
-
-			Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceCalls()), ShouldEqual, 1)
-			})
-
-			Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
-				calls := storerMock.CreateInstanceCalls()
-				So(len(calls), ShouldEqual, 1)
-				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-			})
-
-			Convey("And storer.InsertDimension is called at least once with the expected parameters", func() {
-				calls := storerMock.InsertDimensionCalls()
-				So(len(calls), ShouldBeGreaterThan, 0) // may be 1 or 2 depending on when go routines run
-				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-				So(calls[0].Dimension.DimensionID, ShouldEqual, "1234567890_Geography")
-			})
-
-			Convey("And storerMock.GetCodesOrder is called at least once with the expected paramters", func() {
-				calls := storerMock.GetCodesOrderCalls()
-				So(len(calls), ShouldBeGreaterThan, 0)
-
-				So(calls[0].CodeListID, ShouldEqual, testCodeListID)
-				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option})
-			})
-
-			Convey("And the expected error is returned", func() {
-				So(err.Error(), ShouldEqual, fmt.Errorf("error while attempting to get dimension order using codes: %w", errorMock).Error())
-			})
-
-			Convey("And no further processing of the event takes place.", func() {
-				So(len(datasetAPIMock.PatchInstanceDimensionsCalls()), ShouldEqual, 0)
-				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
-			})
-		})
-
-		Convey("When DatasetAPICli.PatchDimensionOption returns an error", func() {
-			event := event.NewInstance{InstanceID: testInstanceID}
-
-			storerMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
-				return dimension, nil
-			}
-			datasetAPIMock.PatchInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, upserts []*dataset.OptionPost, updates []*dataset.OptionUpdate, ifMatch string) (string, error) {
-				return "", errorMock
-			}
-
-			err := handler.Handle(ctx, event)
-
-			Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 1)
-			})
-
-			Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceCalls()), ShouldEqual, 1)
-			})
-
-			Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
-				calls := storerMock.CreateInstanceCalls()
-				So(len(calls), ShouldEqual, 1)
-				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-			})
-
-			Convey("And storer.InsertDimension is called 2 time with the expected parameters", func() {
-				calls := storerMock.InsertDimensionCalls()
-				So(len(calls), ShouldBeGreaterThan, 0) // may be 1 or 2 depending on when go routines run
-				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-				So(calls[0].Dimension.DimensionID, ShouldEqual, "1234567890_Geography")
-			})
-
-			Convey("And storerMock.GetCodeOrder is called 2 times with the expected paramters", func() {
-				calls := storerMock.GetCodesOrderCalls()
-				So(len(calls), ShouldBeGreaterThan, 0)
-
-				So(calls[0].CodeListID, ShouldEqual, testCodeListID)
-				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option})
-			})
-
-			Convey("And DatasetAPICli.PatchDimensionOption is called at least once with the expected parameters for the first batch", func() {
-				calls := datasetAPIMock.PatchInstanceDimensionsCalls()
-				So(len(calls), ShouldBeGreaterThan, 0)
-
-				So(calls[0].InstanceID, ShouldEqual, testInstanceID)
-				So(calls[0].Upserts, ShouldBeNil)
-				So(calls[0].Updates, ShouldResemble, []*dataset.OptionUpdate{
-					{
-						Name:   d1Api.DimensionID,
-						Option: d1Api.Option,
-						NodeID: d1Api.NodeID,
-						Order:  &d1Order,
-					},
-					{
-						Name:   d2Api.DimensionID,
-						Option: d2Api.Option,
-						NodeID: d2Api.NodeID,
-						Order:  &d2Order,
-					},
-				})
-			})
-
-			Convey("And the expected error is returned", func() {
-				So(err.Error(), ShouldEqual, fmt.Errorf("DatasetAPICli.PatchDimensionOption returned an error: %w", errorMock).Error())
-			})
-
-			Convey("And no further processing of the event takes place.", func() {
-				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
-			})
-		})
-
-		Convey("When storer.AddDimensions returns an error", func() {
-			event := event.NewInstance{InstanceID: testInstanceID}
-
-			storerMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
-				return dimension, nil
-			}
-			datasetAPIMock.PatchInstanceDimensionsFunc = func(ctx context.Context, serviceAuthToken string, instanceID string, upserts []*dataset.OptionPost, updates []*dataset.OptionUpdate, ifMatch string) (string, error) {
-				return "", nil
-			}
-			storerMock.AddDimensionsFunc = func(ctx context.Context, instanceID string, dimensions []interface{}) error {
-				return errorMock
-			}
-
-			err := handler.Handle(ctx, event)
-
-			Convey("Then the DatasetAPICli.GetInstanceDimensions is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 1)
-			})
-
-			Convey("Then DatasetAPICli.GetInstance is called 1 time", func() {
-				So(len(datasetAPIMock.GetInstanceCalls()), ShouldEqual, 1)
-			})
-
-			Convey("And storer.CreateInstance is called 1 time with the expected parameters", func() {
-				calls := storerMock.CreateInstanceCalls()
-				So(len(calls), ShouldEqual, 1)
-				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-			})
-
-			Convey("And storer.InsertDimension is called 2 time with the expected parameters", func() {
-				validateInsertDimensionCalls(storerMock, 2, instance.DbModel().InstanceID, d1.DbModel(), d2.DbModel())
-			})
-
-			Convey("And storerMock.GetCodeOrder is called 1 time with the expected paramters", func() {
-				calls := storerMock.GetCodesOrderCalls()
-				So(len(calls), ShouldEqual, 1)
-
-				So(calls[0].CodeListID, ShouldEqual, testCodeListID)
-				So(calls[0].Codes, ShouldResemble, []string{d1Api.Option, d2Api.Option})
-			})
-
-			Convey("And DatasetAPICli.PatchDimensionOption is called 1 time with the expected parameters", func() {
-				calls := datasetAPIMock.PatchInstanceDimensionsCalls()
-				So(len(calls), ShouldEqual, 1)
-
-				So(calls[0].InstanceID, ShouldEqual, testInstanceID)
-				So(calls[0].Upserts, ShouldBeNil)
-				So(calls[0].Updates, ShouldResemble, []*dataset.OptionUpdate{
-					{
-						Name:   d1Api.DimensionID,
-						Option: d1Api.Option,
-						NodeID: d1Api.NodeID,
-						Order:  &d1Order,
-					},
-					{
-						Name:   d2Api.DimensionID,
-						Option: d2Api.Option,
-						NodeID: d2Api.NodeID,
-						Order:  &d2Order,
-					},
-				})
-			})
-
-			Convey("And the expected error is returned", func() {
-				So(err.Error(), ShouldEqual, fmt.Errorf("AddDimensions returned an error: %w", errorMock).Error())
-			})
+		Convey("And the expected error is returned", func() {
+			So(err.Error(), ShouldEqual, fmt.Errorf("AddDimensions returned an error: %w", errorMock).Error())
 		})
 	})
 
@@ -523,8 +552,7 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		db := &storertest.StorerMock{}
 
 		handler := handler.InstanceEventHandler{
-			DatasetAPICli: nil,
-			Store:         db,
+			Store: db,
 		}
 
 		Convey("When Handle is called", func() {
@@ -533,12 +561,6 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 
 			Convey("Then the expected error is returned", func() {
 				So(err.Error(), ShouldEqual, "validation error dataset api client required but was nil")
-			})
-
-			Convey("And the event is not handled", func() {
-				So(len(db.InsertDimensionCalls()), ShouldEqual, 0)
-				So(len(db.AddDimensionsCalls()), ShouldEqual, 0)
-				So(len(db.CreateInstanceCalls()), ShouldEqual, 0)
 			})
 		})
 	})
@@ -562,54 +584,32 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 			Convey("Then the expected error is returned", func() {
 				So(err.Error(), ShouldEqual, "validation error datastore required but was nil")
 			})
-			Convey("And the event is not handled", func() {
-				So(len(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 0)
-				So(len(datasetAPIMock.PatchInstanceDimensionsCalls()), ShouldEqual, 0)
-			})
 		})
 	})
 }
 
 func TestInstanceEventHandler_Handle_ExistingInstance(t *testing.T) {
 	Convey("Given an instance with the event ID already exists", t, func() {
-		storerMock, datasetAPIMock, completedProducer, handler := setUp()
-
-		// override default
-		storerMock.InstanceExistsFunc = func(ctx context.Context, instanceID string) (bool, error) {
-			return true, nil
+		// Set up mocks, with existing instance
+		storerMock := &storertest.StorerMock{
+			InstanceExistsFunc: func(ctx context.Context, instanceID string) (bool, error) {
+				return true, nil
+			},
 		}
+		datasetAPIMock := datasetAPIMockHappy()
+		handler := setUp(storerMock, datasetAPIMock, nil)
 
 		Convey("When Handle is given a NewInstance event with the same instanceID", func() {
 			handler.Handle(ctx, newInstance)
 
 			Convey("Then storer.InstanceExists is called 1 time with expected parameters ", func() {
 				calls := storerMock.InstanceExistsCalls()
-				So(len(calls), ShouldEqual, 1)
+				So(calls, ShouldHaveLength, 1)
 				So(calls[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
 			})
 
-			Convey("And storer.CreateInstance is not called", func() {
-				So(len(storerMock.CreateInstanceCalls()), ShouldEqual, 0)
-			})
-
-			Convey("And storer.InsertDimension is not called", func() {
-				So(len(storerMock.InsertDimensionCalls()), ShouldEqual, 0)
-			})
-
 			Convey("And DatasetAPICli.PatchDimensionOption not called", func() {
-				So(len(datasetAPIMock.PatchInstanceDimensionsCalls()), ShouldEqual, 0)
-			})
-
-			Convey("and storer.AddDimensions is not called", func() {
-				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
-			})
-
-			Convey("And storer is not called to create constraints", func() {
-				So(len(storerMock.CreateInstanceConstraintCalls()), ShouldEqual, 0)
-			})
-
-			Convey("And Producer.Completed is not called", func() {
-				So(len(completedProducer.CompletedCalls()), ShouldEqual, 0)
+				So(datasetAPIMock.PatchInstanceDimensionsCalls(), ShouldHaveLength, 0)
 			})
 		})
 	})
@@ -617,7 +617,14 @@ func TestInstanceEventHandler_Handle_ExistingInstance(t *testing.T) {
 
 func TestInstanceEventHandler_Handle_InstanceExistsErr(t *testing.T) {
 	Convey("Given handler has been configured correctly", t, func() {
-		storerMock, datasetAPIMock, completedProducer, handler := setUp()
+		// Set up mocks, with InstanceExists returning an error
+		storerMock := &storertest.StorerMock{
+			InstanceExistsFunc: func(ctx context.Context, instanceID string) (bool, error) {
+				return false, errorMock
+			},
+		}
+		datasetAPIMock := datasetAPIMockHappy()
+		handler := setUp(storerMock, datasetAPIMock, nil)
 
 		Convey("When storer.InstanceExists returns an error", func() {
 			storerMock.InstanceExistsFunc = func(ctx context.Context, instanceID string) (bool, error) {
@@ -631,36 +638,25 @@ func TestInstanceEventHandler_Handle_InstanceExistsErr(t *testing.T) {
 			})
 
 			Convey("And datasetAPICli make the expected calls with the expected parameters", func() {
-				So(len(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()), ShouldEqual, 1)
+				So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls(), ShouldHaveLength, 1)
 				So(datasetAPIMock.GetInstanceDimensionsInBatchesCalls()[0].InstanceID, ShouldEqual, testInstanceID)
 
-				So(len(datasetAPIMock.GetInstanceCalls()), ShouldEqual, 1)
+				So(datasetAPIMock.GetInstanceCalls(), ShouldHaveLength, 1)
 				So(datasetAPIMock.GetInstanceCalls()[0].InstanceID, ShouldEqual, testInstanceID)
 
-				So(len(datasetAPIMock.PatchInstanceDimensionsCalls()), ShouldEqual, 0)
+				So(datasetAPIMock.PatchInstanceDimensionsCalls(), ShouldHaveLength, 0)
 			})
 
 			Convey("And storer makes the expected called with the expected parameters", func() {
-				So(len(storerMock.InstanceExistsCalls()), ShouldEqual, 1)
+				So(storerMock.InstanceExistsCalls(), ShouldHaveLength, 1)
 				So(storerMock.InstanceExistsCalls()[0].InstanceID, ShouldResemble, instance.DbModel().InstanceID)
-				So(len(storerMock.CreateInstanceCalls()), ShouldEqual, 0)
-				So(len(storerMock.AddDimensionsCalls()), ShouldEqual, 0)
-				So(len(storerMock.GetCodesOrderCalls()), ShouldEqual, 0)
-				So(len(storerMock.InsertDimensionCalls()), ShouldEqual, 0)
-				So(len(storerMock.CreateInstanceConstraintCalls()), ShouldEqual, 0)
-			})
-
-			Convey("And producer is never called", func() {
-				So(len(completedProducer.CompletedCalls()), ShouldEqual, 0)
 			})
 		})
-
 	})
 }
 
-// Default set up for the mocks.
-func setUp() (*storertest.StorerMock, *mocks.IClientMock, *mocks.CompletedProducerMock, handler.InstanceEventHandler) {
-	storeMock := &storertest.StorerMock{
+func storerMockHappy() *storertest.StorerMock {
+	return &storertest.StorerMock{
 		InstanceExistsFunc: func(ctx context.Context, instanceID string) (bool, error) {
 			return false, nil
 		},
@@ -690,10 +686,12 @@ func setUp() (*storertest.StorerMock, *mocks.IClientMock, *mocks.CompletedProduc
 			return nil
 		},
 	}
+}
 
-	datasetAPIMock := &mocks.IClientMock{
+func datasetAPIMockHappy() *mocks.IClientMock {
+	return &mocks.IClientMock{
 		GetInstanceDimensionsInBatchesFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, maxWorkers, batchSize int) (dataset.Dimensions, string, error) {
-			return dataset.Dimensions{Items: []dataset.Dimension{d1Api, d2Api}}, "", nil
+			return dataset.Dimensions{Items: []dataset.Dimension{d1Api, d2Api, d3Api}}, "", nil
 		},
 		PatchInstanceDimensionsFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, upserts []*dataset.OptionPost, updates []*dataset.OptionUpdate, ifMatch string) (string, error) {
 			return "", nil
@@ -702,26 +700,30 @@ func setUp() (*storertest.StorerMock, *mocks.IClientMock, *mocks.CompletedProduc
 			return instanceApi, "", nil
 		},
 	}
-	datasetAPIClient := &client.DatasetAPI{
-		AuthToken:      "token",
-		DatasetAPIHost: "host",
-		Client:         datasetAPIMock,
-	}
-
-	completedProducer := &mocks.CompletedProducerMock{
+}
+func completedProducerHappy() *mocks.CompletedProducerMock {
+	return &mocks.CompletedProducerMock{
 		CompletedFunc: func(ctx context.Context, e event.InstanceCompleted) error {
 			return nil
 		},
 	}
+}
 
-	handler := handler.InstanceEventHandler{
+// Default set up for the handler with provided mocks
+func setUp(storeMock *storertest.StorerMock, datasetAPIMock *mocks.IClientMock, completedProducer *mocks.CompletedProducerMock) handler.InstanceEventHandler {
+	datasetAPIClient := &client.DatasetAPI{
+		AuthToken:      "token",
+		DatasetAPIHost: "host",
+		Client:         datasetAPIMock,
+		BatchSize:      testBatchSize,
+	}
+	return handler.InstanceEventHandler{
 		Store:             storeMock,
 		DatasetAPICli:     datasetAPIClient,
 		Producer:          completedProducer,
 		EnablePatchNodeID: true,
 		BatchSize:         testBatchSize,
 	}
-	return storeMock, datasetAPIMock, completedProducer, handler
 }
 
 // validateInsertDimensionCalls validates the following for InsertDimensionCalls:

--- a/message/consumer_test.go
+++ b/message/consumer_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ONSdigital/dp-dimension-importer/config"
 	"github.com/ONSdigital/dp-dimension-importer/message"
-	mock "github.com/ONSdigital/dp-dimension-importer/message/mock"
+	"github.com/ONSdigital/dp-dimension-importer/message/mock"
 	kafka "github.com/ONSdigital/dp-kafka/v2"
 	"github.com/ONSdigital/dp-kafka/v2/kafkatest"
 	. "github.com/smartystreets/goconvey/convey"

--- a/message/kafka_message_receiver_test.go
+++ b/message/kafka_message_receiver_test.go
@@ -42,7 +42,7 @@ func TestKafkaMessageHandler_Handle(t *testing.T) {
 			So(fixture.instanceHdlrCalls[0], ShouldResemble, newInstanceEvent)
 		})
 
-		Convey("And ErrorReporter.Notify is never called", func() {
+		Convey("Then ErrorReporter.Notify is never called", func() {
 			So(len(fixture.errorReporter.NotifyCalls()), ShouldEqual, 0)
 		})
 	})
@@ -68,7 +68,7 @@ func TestKafkaMessageHandler_Handle_InvalidKafkaMessage(t *testing.T) {
 				So(len(fix.errorReporter.NotifyCalls()), ShouldEqual, 0)
 			})
 
-			Convey("And InstanceHandler.OnMessage is never called", func() {
+			Convey("Then InstanceHandler.OnMessage is never called", func() {
 				So(len(fix.instanceHdlrCalls), ShouldEqual, 0)
 			})
 		})
@@ -105,7 +105,7 @@ func TestKafkaMessageHandler_Handle_InstanceHandlerError(t *testing.T) {
 			So(fix.instanceHdlrCalls[0], ShouldResemble, newInstanceEvent)
 		})
 
-		Convey("And ErrorReporter.Notify is called 1 time with the expected parameters", func() {
+		Convey("Then ErrorReporter.Notify is called 1 time with the expected parameters", func() {
 			So(len(fix.errorReporter.NotifyCalls()), ShouldEqual, 1)
 			So(fix.errorReporter.NotifyCalls()[0].ErrContext, ShouldEqual, "InstanceHandler.Handle returned an unexpected error")
 		})

--- a/message/kafka_message_receiver_test.go
+++ b/message/kafka_message_receiver_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ONSdigital/dp-dimension-importer/event"
 	"github.com/ONSdigital/dp-dimension-importer/message"
-	mock "github.com/ONSdigital/dp-dimension-importer/message/mock"
+	"github.com/ONSdigital/dp-dimension-importer/message/mock"
 	"github.com/ONSdigital/dp-dimension-importer/schema"
 	"github.com/ONSdigital/dp-kafka/v2/kafkatest"
 	"github.com/ONSdigital/dp-reporter-client/reporter/reportertest"
@@ -83,7 +83,7 @@ func TestKafkaMessageHandler_Handle_InstanceHandlerError(t *testing.T) {
 	}
 	avroBytes, _ := schema.NewInstanceSchema.Marshal(newInstanceEvent)
 
-	instanceHandlerErr := errors.New("Boom!")
+	instanceHandlerErr := errors.New("boom!")
 	handleInstanceFunc := func(e event.NewInstance) error {
 		return instanceHandlerErr
 	}

--- a/message/mock/instance_event_handler.go
+++ b/message/mock/instance_event_handler.go
@@ -10,25 +10,29 @@ import (
 	"sync"
 )
 
+var (
+	lockInstanceEventHandlerMockHandle sync.RWMutex
+)
+
 // Ensure, that InstanceEventHandlerMock does implement message.InstanceEventHandler.
 // If this is not the case, regenerate this file with moq.
 var _ message.InstanceEventHandler = &InstanceEventHandlerMock{}
 
 // InstanceEventHandlerMock is a mock implementation of message.InstanceEventHandler.
 //
-// 	func TestSomethingThatUsesInstanceEventHandler(t *testing.T) {
+//     func TestSomethingThatUsesInstanceEventHandler(t *testing.T) {
 //
-// 		// make and configure a mocked message.InstanceEventHandler
-// 		mockedInstanceEventHandler := &InstanceEventHandlerMock{
-// 			HandleFunc: func(ctx context.Context, e event.NewInstance) error {
-// 				panic("mock out the Handle method")
-// 			},
-// 		}
+//         // make and configure a mocked message.InstanceEventHandler
+//         mockedInstanceEventHandler := &InstanceEventHandlerMock{
+//             HandleFunc: func(ctx context.Context, e event.NewInstance) error {
+// 	               panic("mock out the Handle method")
+//             },
+//         }
 //
-// 		// use mockedInstanceEventHandler in code that requires message.InstanceEventHandler
-// 		// and then make assertions.
+//         // use mockedInstanceEventHandler in code that requires message.InstanceEventHandler
+//         // and then make assertions.
 //
-// 	}
+//     }
 type InstanceEventHandlerMock struct {
 	// HandleFunc mocks the Handle method.
 	HandleFunc func(ctx context.Context, e event.NewInstance) error
@@ -43,7 +47,6 @@ type InstanceEventHandlerMock struct {
 			E event.NewInstance
 		}
 	}
-	lockHandle sync.RWMutex
 }
 
 // Handle calls HandleFunc.
@@ -58,9 +61,9 @@ func (mock *InstanceEventHandlerMock) Handle(ctx context.Context, e event.NewIns
 		Ctx: ctx,
 		E:   e,
 	}
-	mock.lockHandle.Lock()
+	lockInstanceEventHandlerMockHandle.Lock()
 	mock.calls.Handle = append(mock.calls.Handle, callInfo)
-	mock.lockHandle.Unlock()
+	lockInstanceEventHandlerMockHandle.Unlock()
 	return mock.HandleFunc(ctx, e)
 }
 
@@ -75,8 +78,8 @@ func (mock *InstanceEventHandlerMock) HandleCalls() []struct {
 		Ctx context.Context
 		E   event.NewInstance
 	}
-	mock.lockHandle.RLock()
+	lockInstanceEventHandlerMockHandle.RLock()
 	calls = mock.calls.Handle
-	mock.lockHandle.RUnlock()
+	lockInstanceEventHandlerMockHandle.RUnlock()
 	return calls
 }

--- a/message/mock/producer.go
+++ b/message/mock/producer.go
@@ -8,25 +8,29 @@ import (
 	"sync"
 )
 
+var (
+	lockMarshallerMockMarshal sync.RWMutex
+)
+
 // Ensure, that MarshallerMock does implement message.Marshaller.
 // If this is not the case, regenerate this file with moq.
 var _ message.Marshaller = &MarshallerMock{}
 
 // MarshallerMock is a mock implementation of message.Marshaller.
 //
-// 	func TestSomethingThatUsesMarshaller(t *testing.T) {
+//     func TestSomethingThatUsesMarshaller(t *testing.T) {
 //
-// 		// make and configure a mocked message.Marshaller
-// 		mockedMarshaller := &MarshallerMock{
-// 			MarshalFunc: func(s interface{}) ([]byte, error) {
-// 				panic("mock out the Marshal method")
-// 			},
-// 		}
+//         // make and configure a mocked message.Marshaller
+//         mockedMarshaller := &MarshallerMock{
+//             MarshalFunc: func(s interface{}) ([]byte, error) {
+// 	               panic("mock out the Marshal method")
+//             },
+//         }
 //
-// 		// use mockedMarshaller in code that requires message.Marshaller
-// 		// and then make assertions.
+//         // use mockedMarshaller in code that requires message.Marshaller
+//         // and then make assertions.
 //
-// 	}
+//     }
 type MarshallerMock struct {
 	// MarshalFunc mocks the Marshal method.
 	MarshalFunc func(s interface{}) ([]byte, error)
@@ -39,7 +43,6 @@ type MarshallerMock struct {
 			S interface{}
 		}
 	}
-	lockMarshal sync.RWMutex
 }
 
 // Marshal calls MarshalFunc.
@@ -52,9 +55,9 @@ func (mock *MarshallerMock) Marshal(s interface{}) ([]byte, error) {
 	}{
 		S: s,
 	}
-	mock.lockMarshal.Lock()
+	lockMarshallerMockMarshal.Lock()
 	mock.calls.Marshal = append(mock.calls.Marshal, callInfo)
-	mock.lockMarshal.Unlock()
+	lockMarshallerMockMarshal.Unlock()
 	return mock.MarshalFunc(s)
 }
 
@@ -67,8 +70,8 @@ func (mock *MarshallerMock) MarshalCalls() []struct {
 	var calls []struct {
 		S interface{}
 	}
-	mock.lockMarshal.RLock()
+	lockMarshallerMockMarshal.RLock()
 	calls = mock.calls.Marshal
-	mock.lockMarshal.RUnlock()
+	lockMarshallerMockMarshal.RUnlock()
 	return calls
 }

--- a/message/producer_test.go
+++ b/message/producer_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ONSdigital/dp-dimension-importer/event"
 	"github.com/ONSdigital/dp-dimension-importer/message"
-	mock "github.com/ONSdigital/dp-dimension-importer/message/mock"
+	"github.com/ONSdigital/dp-dimension-importer/message/mock"
 	"github.com/ONSdigital/dp-dimension-importer/schema"
 	kafka "github.com/ONSdigital/dp-kafka/v2"
 	"github.com/ONSdigital/dp-kafka/v2/kafkatest"
@@ -64,8 +64,9 @@ func TestInstanceCompletedProducer_Completed(t *testing.T) {
 
 				Convey("Then the expected bytes are sent to producer.output", func() {
 					var actual event.InstanceCompleted
-					schema.InstanceCompletedSchema.Unmarshal(avroBytes, &actual)
+					err := schema.InstanceCompletedSchema.Unmarshal(avroBytes, &actual)
 					So(completedEvent, ShouldResemble, actual)
+					So(err, ShouldBeNil)
 				})
 			})
 		})

--- a/message/producer_test.go
+++ b/message/producer_test.go
@@ -62,7 +62,7 @@ func TestInstanceCompletedProducer_Completed(t *testing.T) {
 			Convey("Then no error is returned", func() {
 				So(err, ShouldBeNil)
 
-				Convey("And the expected bytes are sent to producer.output", func() {
+				Convey("Then the expected bytes are sent to producer.output", func() {
 					var actual event.InstanceCompleted
 					schema.InstanceCompletedSchema.Unmarshal(avroBytes, &actual)
 					So(completedEvent, ShouldResemble, actual)
@@ -103,7 +103,7 @@ func TestInstanceCompletedProducer_Completed_MarshalErr(t *testing.T) {
 				So(err.Error(), ShouldEqual, expectedError.Error())
 			})
 
-			Convey("And producer.Output is never called", func() {
+			Convey("Then producer.Output is never called", func() {
 				So(len(kafkaProducerMock.ChannelsCalls()), ShouldEqual, 0)
 			})
 		})

--- a/mocks/incoming_instance_generated_mocks.go
+++ b/mocks/incoming_instance_generated_mocks.go
@@ -10,25 +10,29 @@ import (
 	"sync"
 )
 
+var (
+	lockCompletedProducerMockCompleted sync.RWMutex
+)
+
 // Ensure, that CompletedProducerMock does implement handler.CompletedProducer.
 // If this is not the case, regenerate this file with moq.
 var _ handler.CompletedProducer = &CompletedProducerMock{}
 
 // CompletedProducerMock is a mock implementation of handler.CompletedProducer.
 //
-// 	func TestSomethingThatUsesCompletedProducer(t *testing.T) {
+//     func TestSomethingThatUsesCompletedProducer(t *testing.T) {
 //
-// 		// make and configure a mocked handler.CompletedProducer
-// 		mockedCompletedProducer := &CompletedProducerMock{
-// 			CompletedFunc: func(ctx context.Context, e event.InstanceCompleted) error {
-// 				panic("mock out the Completed method")
-// 			},
-// 		}
+//         // make and configure a mocked handler.CompletedProducer
+//         mockedCompletedProducer := &CompletedProducerMock{
+//             CompletedFunc: func(ctx context.Context, e event.InstanceCompleted) error {
+// 	               panic("mock out the Completed method")
+//             },
+//         }
 //
-// 		// use mockedCompletedProducer in code that requires handler.CompletedProducer
-// 		// and then make assertions.
+//         // use mockedCompletedProducer in code that requires handler.CompletedProducer
+//         // and then make assertions.
 //
-// 	}
+//     }
 type CompletedProducerMock struct {
 	// CompletedFunc mocks the Completed method.
 	CompletedFunc func(ctx context.Context, e event.InstanceCompleted) error
@@ -43,7 +47,6 @@ type CompletedProducerMock struct {
 			E event.InstanceCompleted
 		}
 	}
-	lockCompleted sync.RWMutex
 }
 
 // Completed calls CompletedFunc.
@@ -58,9 +61,9 @@ func (mock *CompletedProducerMock) Completed(ctx context.Context, e event.Instan
 		Ctx: ctx,
 		E:   e,
 	}
-	mock.lockCompleted.Lock()
+	lockCompletedProducerMockCompleted.Lock()
 	mock.calls.Completed = append(mock.calls.Completed, callInfo)
-	mock.lockCompleted.Unlock()
+	lockCompletedProducerMockCompleted.Unlock()
 	return mock.CompletedFunc(ctx, e)
 }
 
@@ -75,8 +78,8 @@ func (mock *CompletedProducerMock) CompletedCalls() []struct {
 		Ctx context.Context
 		E   event.InstanceCompleted
 	}
-	mock.lockCompleted.RLock()
+	lockCompletedProducerMockCompleted.RLock()
 	calls = mock.calls.Completed
-	mock.lockCompleted.RUnlock()
+	lockCompletedProducerMockCompleted.RUnlock()
 	return calls
 }

--- a/model/models.go
+++ b/model/models.go
@@ -13,12 +13,13 @@ import (
 type Dimension struct {
 	dbDimension *db.Dimension
 	codeListID  string
+	Order       *int
 }
 
 // NewDimension creates a new DB wrapped Dimension from an api dimension
 func NewDimension(dimension *dataset.Dimension) *Dimension {
 	if dimension == nil {
-		return &Dimension{&db.Dimension{}, ""}
+		return &Dimension{&db.Dimension{}, "", nil}
 	}
 	dbDimension := &db.Dimension{
 		DimensionID: dimension.DimensionID,

--- a/model/models_test.go
+++ b/model/models_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	dataset "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	db "github.com/ONSdigital/dp-graph/v2/models"
 
 	. "github.com/smartystreets/goconvey/convey"

--- a/model/models_test.go
+++ b/model/models_test.go
@@ -14,7 +14,7 @@ func TestInstance_Validate(t *testing.T) {
 	Convey("Given Instance is nil", t, func() {
 		var i *Instance
 
-		Convey("When Insert is invoked", func() {
+		Convey("When Validate is invoked", func() {
 			err := i.Validate()
 
 			Convey("Then the expected error is returned", func() {
@@ -26,11 +26,23 @@ func TestInstance_Validate(t *testing.T) {
 	Convey("Given an Instance with an empty instanceID", t, func() {
 		i := &Instance{dbInstance: &db.Instance{InstanceID: ""}}
 
-		Convey("When Insert is invoked", func() {
+		Convey("When Validate is invoked", func() {
 			err := i.Validate()
 
 			Convey("Then the expected error is returned", func() {
 				So(err.Error(), ShouldEqual, errors.New("instance id is required but was empty").Error())
+			})
+		})
+	})
+
+	Convey("Given an Instance with a valid instanceID", t, func() {
+		i := &Instance{dbInstance: &db.Instance{InstanceID: "myInstance"}}
+
+		Convey("When Validate is invoked", func() {
+			err := i.Validate()
+
+			Convey("Then the no error is returned", func() {
+				So(err, ShouldBeNil)
 			})
 		})
 	})
@@ -81,6 +93,18 @@ func TestDimension_Validate(t *testing.T) {
 
 			Convey("Then the expected error is returned with a nil dimension", func() {
 				So(err.Error(), ShouldEqual, errors.New("dimension value is required but was empty").Error())
+			})
+		})
+	})
+
+	Convey("Given a dimension with dimensionID and option", t, func() {
+		d := &Dimension{&db.Dimension{DimensionID: "id", Option: "myOption"}, "", nil}
+
+		Convey("When validateDimension is called", func() {
+			err := d.Validate()
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
 			})
 		})
 	})

--- a/model/models_test.go
+++ b/model/models_test.go
@@ -50,7 +50,7 @@ func TestDimension_Validate(t *testing.T) {
 	})
 
 	Convey("Given a dimension with an empty dimensionID", t, func() {
-		d := &Dimension{&db.Dimension{Option: "10"}, ""}
+		d := &Dimension{&db.Dimension{Option: "10"}, "", nil}
 
 		Convey("When validateDimension is called", func() {
 			err := d.Validate()
@@ -62,7 +62,7 @@ func TestDimension_Validate(t *testing.T) {
 	})
 
 	Convey("Given a dimension with an empty dimensionID and option", t, func() {
-		d := &Dimension{&db.Dimension{DimensionID: "", Option: ""}, ""}
+		d := &Dimension{&db.Dimension{DimensionID: "", Option: ""}, "", nil}
 
 		Convey("When validateDimension is called", func() {
 			err := d.Validate()
@@ -74,7 +74,7 @@ func TestDimension_Validate(t *testing.T) {
 	})
 
 	Convey("Given a dimension with an empty option", t, func() {
-		d := &Dimension{&db.Dimension{DimensionID: "id"}, ""}
+		d := &Dimension{&db.Dimension{DimensionID: "id"}, "", nil}
 
 		Convey("When validateDimension is called", func() {
 			err := d.Validate()
@@ -88,7 +88,7 @@ func TestDimension_Validate(t *testing.T) {
 
 func TestDimension_New(t *testing.T) {
 
-	emptyDimension := &Dimension{&db.Dimension{}, ""}
+	emptyDimension := &Dimension{&db.Dimension{}, "", nil}
 
 	Convey("Given a new dimension with a nil pointer dataset API model", t, func() {
 		d := NewDimension(nil)

--- a/store/storertest/storer.go
+++ b/store/storertest/storer.go
@@ -11,52 +11,65 @@ import (
 	"sync"
 )
 
+var (
+	lockStorerMockAddDimensions            sync.RWMutex
+	lockStorerMockChecker                  sync.RWMutex
+	lockStorerMockClose                    sync.RWMutex
+	lockStorerMockCreateCodeRelationship   sync.RWMutex
+	lockStorerMockCreateInstance           sync.RWMutex
+	lockStorerMockCreateInstanceConstraint sync.RWMutex
+	lockStorerMockErrorChan                sync.RWMutex
+	lockStorerMockGetCodesOrder            sync.RWMutex
+	lockStorerMockInsertDimension          sync.RWMutex
+	lockStorerMockInstanceExists           sync.RWMutex
+)
+
 // Ensure, that StorerMock does implement store.Storer.
 // If this is not the case, regenerate this file with moq.
 var _ store.Storer = &StorerMock{}
 
 // StorerMock is a mock implementation of store.Storer.
 //
-// 	func TestSomethingThatUsesStorer(t *testing.T) {
+//     func TestSomethingThatUsesStorer(t *testing.T) {
 //
-// 		// make and configure a mocked store.Storer
-// 		mockedStorer := &StorerMock{
-// 			AddDimensionsFunc: func(ctx context.Context, instanceID string, dimensions []interface{}) error {
-// 				panic("mock out the AddDimensions method")
-// 			},
-// 			CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
-// 				panic("mock out the Checker method")
-// 			},
-// 			CloseFunc: func(ctx context.Context) error {
-// 				panic("mock out the Close method")
-// 			},
-// 			CreateCodeRelationshipFunc: func(ctx context.Context, instanceID string, codeListID string, code string) error {
-// 				panic("mock out the CreateCodeRelationship method")
-// 			},
-// 			CreateInstanceFunc: func(ctx context.Context, instanceID string, csvHeaders []string) error {
-// 				panic("mock out the CreateInstance method")
-// 			},
-// 			CreateInstanceConstraintFunc: func(ctx context.Context, instanceID string) error {
-// 				panic("mock out the CreateInstanceConstraint method")
-// 			},
-// 			ErrorChanFunc: func() chan error {
-// 				panic("mock out the ErrorChan method")
-// 			},
-// 			GetCodesOrderFunc: func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
-// 				panic("mock out the GetCodesOrder method")
-// 			},
-// 			InsertDimensionFunc: func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
-// 				panic("mock out the InsertDimension method")
-// 			},
-// 			InstanceExistsFunc: func(ctx context.Context, instanceID string) (bool, error) {
-// 				panic("mock out the InstanceExists method")
-// 			},
-// 		}
+//         // make and configure a mocked store.Storer
+//         mockedStorer := &StorerMock{
+//             AddDimensionsFunc: func(ctx context.Context, instanceID string, dimensions []interface{}) error {
+// 	               panic("mock out the AddDimensions method")
+//             },
+//             CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
+// 	               panic("mock out the Checker method")
+//             },
+//             CloseFunc: func(ctx context.Context) error {
+// 	               panic("mock out the Close method")
+//             },
+//             CreateCodeRelationshipFunc: func(ctx context.Context, instanceID string, codeListID string, code string) error {
+// 	               panic("mock out the CreateCodeRelationship method")
+//             },
+//             CreateInstanceFunc: func(ctx context.Context, instanceID string, csvHeaders []string) error {
+// 	               panic("mock out the CreateInstance method")
+//             },
+//             CreateInstanceConstraintFunc: func(ctx context.Context, instanceID string) error {
+// 	               panic("mock out the CreateInstanceConstraint method")
+//             },
+//             ErrorChanFunc: func() chan error {
+// 	               panic("mock out the ErrorChan method")
+//             },
+//             GetCodesOrderFunc: func(ctx context.Context, codeListID string, codes []string) (map[string]*int, error) {
+// 	               panic("mock out the GetCodesOrder method")
+//             },
+//             InsertDimensionFunc: func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
+// 	               panic("mock out the InsertDimension method")
+//             },
+//             InstanceExistsFunc: func(ctx context.Context, instanceID string) (bool, error) {
+// 	               panic("mock out the InstanceExists method")
+//             },
+//         }
 //
-// 		// use mockedStorer in code that requires store.Storer
-// 		// and then make assertions.
+//         // use mockedStorer in code that requires store.Storer
+//         // and then make assertions.
 //
-// 	}
+//     }
 type StorerMock struct {
 	// AddDimensionsFunc mocks the AddDimensions method.
 	AddDimensionsFunc func(ctx context.Context, instanceID string, dimensions []interface{}) error
@@ -169,16 +182,6 @@ type StorerMock struct {
 			InstanceID string
 		}
 	}
-	lockAddDimensions            sync.RWMutex
-	lockChecker                  sync.RWMutex
-	lockClose                    sync.RWMutex
-	lockCreateCodeRelationship   sync.RWMutex
-	lockCreateInstance           sync.RWMutex
-	lockCreateInstanceConstraint sync.RWMutex
-	lockErrorChan                sync.RWMutex
-	lockGetCodesOrder            sync.RWMutex
-	lockInsertDimension          sync.RWMutex
-	lockInstanceExists           sync.RWMutex
 }
 
 // AddDimensions calls AddDimensionsFunc.
@@ -195,9 +198,9 @@ func (mock *StorerMock) AddDimensions(ctx context.Context, instanceID string, di
 		InstanceID: instanceID,
 		Dimensions: dimensions,
 	}
-	mock.lockAddDimensions.Lock()
+	lockStorerMockAddDimensions.Lock()
 	mock.calls.AddDimensions = append(mock.calls.AddDimensions, callInfo)
-	mock.lockAddDimensions.Unlock()
+	lockStorerMockAddDimensions.Unlock()
 	return mock.AddDimensionsFunc(ctx, instanceID, dimensions)
 }
 
@@ -214,9 +217,9 @@ func (mock *StorerMock) AddDimensionsCalls() []struct {
 		InstanceID string
 		Dimensions []interface{}
 	}
-	mock.lockAddDimensions.RLock()
+	lockStorerMockAddDimensions.RLock()
 	calls = mock.calls.AddDimensions
-	mock.lockAddDimensions.RUnlock()
+	lockStorerMockAddDimensions.RUnlock()
 	return calls
 }
 
@@ -232,9 +235,9 @@ func (mock *StorerMock) Checker(ctx context.Context, state *healthcheck.CheckSta
 		Ctx:   ctx,
 		State: state,
 	}
-	mock.lockChecker.Lock()
+	lockStorerMockChecker.Lock()
 	mock.calls.Checker = append(mock.calls.Checker, callInfo)
-	mock.lockChecker.Unlock()
+	lockStorerMockChecker.Unlock()
 	return mock.CheckerFunc(ctx, state)
 }
 
@@ -249,9 +252,9 @@ func (mock *StorerMock) CheckerCalls() []struct {
 		Ctx   context.Context
 		State *healthcheck.CheckState
 	}
-	mock.lockChecker.RLock()
+	lockStorerMockChecker.RLock()
 	calls = mock.calls.Checker
-	mock.lockChecker.RUnlock()
+	lockStorerMockChecker.RUnlock()
 	return calls
 }
 
@@ -265,9 +268,9 @@ func (mock *StorerMock) Close(ctx context.Context) error {
 	}{
 		Ctx: ctx,
 	}
-	mock.lockClose.Lock()
+	lockStorerMockClose.Lock()
 	mock.calls.Close = append(mock.calls.Close, callInfo)
-	mock.lockClose.Unlock()
+	lockStorerMockClose.Unlock()
 	return mock.CloseFunc(ctx)
 }
 
@@ -280,9 +283,9 @@ func (mock *StorerMock) CloseCalls() []struct {
 	var calls []struct {
 		Ctx context.Context
 	}
-	mock.lockClose.RLock()
+	lockStorerMockClose.RLock()
 	calls = mock.calls.Close
-	mock.lockClose.RUnlock()
+	lockStorerMockClose.RUnlock()
 	return calls
 }
 
@@ -302,9 +305,9 @@ func (mock *StorerMock) CreateCodeRelationship(ctx context.Context, instanceID s
 		CodeListID: codeListID,
 		Code:       code,
 	}
-	mock.lockCreateCodeRelationship.Lock()
+	lockStorerMockCreateCodeRelationship.Lock()
 	mock.calls.CreateCodeRelationship = append(mock.calls.CreateCodeRelationship, callInfo)
-	mock.lockCreateCodeRelationship.Unlock()
+	lockStorerMockCreateCodeRelationship.Unlock()
 	return mock.CreateCodeRelationshipFunc(ctx, instanceID, codeListID, code)
 }
 
@@ -323,9 +326,9 @@ func (mock *StorerMock) CreateCodeRelationshipCalls() []struct {
 		CodeListID string
 		Code       string
 	}
-	mock.lockCreateCodeRelationship.RLock()
+	lockStorerMockCreateCodeRelationship.RLock()
 	calls = mock.calls.CreateCodeRelationship
-	mock.lockCreateCodeRelationship.RUnlock()
+	lockStorerMockCreateCodeRelationship.RUnlock()
 	return calls
 }
 
@@ -343,9 +346,9 @@ func (mock *StorerMock) CreateInstance(ctx context.Context, instanceID string, c
 		InstanceID: instanceID,
 		CsvHeaders: csvHeaders,
 	}
-	mock.lockCreateInstance.Lock()
+	lockStorerMockCreateInstance.Lock()
 	mock.calls.CreateInstance = append(mock.calls.CreateInstance, callInfo)
-	mock.lockCreateInstance.Unlock()
+	lockStorerMockCreateInstance.Unlock()
 	return mock.CreateInstanceFunc(ctx, instanceID, csvHeaders)
 }
 
@@ -362,9 +365,9 @@ func (mock *StorerMock) CreateInstanceCalls() []struct {
 		InstanceID string
 		CsvHeaders []string
 	}
-	mock.lockCreateInstance.RLock()
+	lockStorerMockCreateInstance.RLock()
 	calls = mock.calls.CreateInstance
-	mock.lockCreateInstance.RUnlock()
+	lockStorerMockCreateInstance.RUnlock()
 	return calls
 }
 
@@ -380,9 +383,9 @@ func (mock *StorerMock) CreateInstanceConstraint(ctx context.Context, instanceID
 		Ctx:        ctx,
 		InstanceID: instanceID,
 	}
-	mock.lockCreateInstanceConstraint.Lock()
+	lockStorerMockCreateInstanceConstraint.Lock()
 	mock.calls.CreateInstanceConstraint = append(mock.calls.CreateInstanceConstraint, callInfo)
-	mock.lockCreateInstanceConstraint.Unlock()
+	lockStorerMockCreateInstanceConstraint.Unlock()
 	return mock.CreateInstanceConstraintFunc(ctx, instanceID)
 }
 
@@ -397,9 +400,9 @@ func (mock *StorerMock) CreateInstanceConstraintCalls() []struct {
 		Ctx        context.Context
 		InstanceID string
 	}
-	mock.lockCreateInstanceConstraint.RLock()
+	lockStorerMockCreateInstanceConstraint.RLock()
 	calls = mock.calls.CreateInstanceConstraint
-	mock.lockCreateInstanceConstraint.RUnlock()
+	lockStorerMockCreateInstanceConstraint.RUnlock()
 	return calls
 }
 
@@ -410,9 +413,9 @@ func (mock *StorerMock) ErrorChan() chan error {
 	}
 	callInfo := struct {
 	}{}
-	mock.lockErrorChan.Lock()
+	lockStorerMockErrorChan.Lock()
 	mock.calls.ErrorChan = append(mock.calls.ErrorChan, callInfo)
-	mock.lockErrorChan.Unlock()
+	lockStorerMockErrorChan.Unlock()
 	return mock.ErrorChanFunc()
 }
 
@@ -423,9 +426,9 @@ func (mock *StorerMock) ErrorChanCalls() []struct {
 } {
 	var calls []struct {
 	}
-	mock.lockErrorChan.RLock()
+	lockStorerMockErrorChan.RLock()
 	calls = mock.calls.ErrorChan
-	mock.lockErrorChan.RUnlock()
+	lockStorerMockErrorChan.RUnlock()
 	return calls
 }
 
@@ -443,9 +446,9 @@ func (mock *StorerMock) GetCodesOrder(ctx context.Context, codeListID string, co
 		CodeListID: codeListID,
 		Codes:      codes,
 	}
-	mock.lockGetCodesOrder.Lock()
+	lockStorerMockGetCodesOrder.Lock()
 	mock.calls.GetCodesOrder = append(mock.calls.GetCodesOrder, callInfo)
-	mock.lockGetCodesOrder.Unlock()
+	lockStorerMockGetCodesOrder.Unlock()
 	return mock.GetCodesOrderFunc(ctx, codeListID, codes)
 }
 
@@ -462,9 +465,9 @@ func (mock *StorerMock) GetCodesOrderCalls() []struct {
 		CodeListID string
 		Codes      []string
 	}
-	mock.lockGetCodesOrder.RLock()
+	lockStorerMockGetCodesOrder.RLock()
 	calls = mock.calls.GetCodesOrder
-	mock.lockGetCodesOrder.RUnlock()
+	lockStorerMockGetCodesOrder.RUnlock()
 	return calls
 }
 
@@ -484,9 +487,9 @@ func (mock *StorerMock) InsertDimension(ctx context.Context, cache map[string]st
 		InstanceID: instanceID,
 		Dimension:  dimension,
 	}
-	mock.lockInsertDimension.Lock()
+	lockStorerMockInsertDimension.Lock()
 	mock.calls.InsertDimension = append(mock.calls.InsertDimension, callInfo)
-	mock.lockInsertDimension.Unlock()
+	lockStorerMockInsertDimension.Unlock()
 	return mock.InsertDimensionFunc(ctx, cache, instanceID, dimension)
 }
 
@@ -505,9 +508,9 @@ func (mock *StorerMock) InsertDimensionCalls() []struct {
 		InstanceID string
 		Dimension  *models.Dimension
 	}
-	mock.lockInsertDimension.RLock()
+	lockStorerMockInsertDimension.RLock()
 	calls = mock.calls.InsertDimension
-	mock.lockInsertDimension.RUnlock()
+	lockStorerMockInsertDimension.RUnlock()
 	return calls
 }
 
@@ -523,9 +526,9 @@ func (mock *StorerMock) InstanceExists(ctx context.Context, instanceID string) (
 		Ctx:        ctx,
 		InstanceID: instanceID,
 	}
-	mock.lockInstanceExists.Lock()
+	lockStorerMockInstanceExists.Lock()
 	mock.calls.InstanceExists = append(mock.calls.InstanceExists, callInfo)
-	mock.lockInstanceExists.Unlock()
+	lockStorerMockInstanceExists.Unlock()
 	return mock.InstanceExistsFunc(ctx, instanceID)
 }
 
@@ -540,8 +543,8 @@ func (mock *StorerMock) InstanceExistsCalls() []struct {
 		Ctx        context.Context
 		InstanceID string
 	}
-	mock.lockInstanceExists.RLock()
+	lockStorerMockInstanceExists.RLock()
 	calls = mock.calls.InstanceExists
-	mock.lockInstanceExists.RUnlock()
+	lockStorerMockInstanceExists.RUnlock()
 	return calls
 }


### PR DESCRIPTION
### What

- Use new patch endpoint to update node_id and order values for dimension options
  - Do 1 call per batch
  - Get order in a single call per codelistID (dpgrah)

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (info) validated by testing a cmd import locally, which was successful by using this branch and the latest develop for the rest of services

### Who can review

Anyone
