### PR TITLE
use latest version of dp-graph with cache concurrency fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.3.0
-	github.com/ONSdigital/dp-graph/v2 v2.13.1
+	github.com/ONSdigital/dp-graph/v2 v2.15.0
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-kafka/v2 v2.2.1
 	github.com/ONSdigital/dp-net v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/ONSdigital/dp-api-clients-go v1.41.1 h1:xkeT6dCTFSAoBpZxgiJUiuqgcfjCX
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.3.0 h1:w0tTGRf3Y/2mvGh5fZ5zVZyukCVAjHsZjgcfvAI2YoA=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.3.0/go.mod h1:do31xNC5k22vAMnbnXGT9NH/7MLAsfR0qeTfiItw/mA=
-github.com/ONSdigital/dp-graph/v2 v2.13.1 h1:txp2WOtmA/S3g4BzcZ2uxcSvp0nBUtZTzWjkbDrSHqs=
-github.com/ONSdigital/dp-graph/v2 v2.13.1/go.mod h1:goNf7IF+hJATF9F8DD8QAHNF38s/0wRMzgHxzOamDKo=
+github.com/ONSdigital/dp-graph/v2 v2.15.0 h1:vDd+GdfJcKXSJ0p6EOZFBkuiYksGsofcoJr6Y0WrwZc=
+github.com/ONSdigital/dp-graph/v2 v2.15.0/go.mod h1:2ZxB5+k+swxWCoeV8yK9YdCIp1SeRokFs2cx2pURTSM=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-healthcheck v1.1.0 h1:fKOf8MMe8l4EW28ljX0wNZ5oZTgx/slAs7lyEx4eq2c=
 github.com/ONSdigital/dp-healthcheck v1.1.0/go.mod h1:vZwyjMJiCHjp/sJ2R1ZEqzZT0rJ0+uHVGwxqdP4J5vg=

--- a/handler/incoming_instance_handler_test.go
+++ b/handler/incoming_instance_handler_test.go
@@ -252,7 +252,7 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 		numCall := 0
 		numCallLock := sync.Mutex{}
 		datasetAPIMock := datasetAPIMockHappy()
-		storerMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
+		storerMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, cacheMutex *sync.Mutex, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
 			defer numCallLock.Unlock()
 			numCallLock.Lock() // we need this lock because this method is called concurrently
 			numCall++
@@ -475,7 +475,7 @@ func TestInstanceEventHandler_Handle(t *testing.T) {
 
 		datasetAPIMock := datasetAPIMockHappy()
 		storerMock := storerMockHappy()
-		storerMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
+		storerMock.InsertDimensionFunc = func(ctx context.Context, cache map[string]string, cacheMutex *sync.Mutex, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
 			return dimension, errorMock
 		}
 		h := setUp(storerMock, datasetAPIMock, nil)
@@ -1018,7 +1018,7 @@ func storerMockHappy() *storertest.StorerMock {
 		CreateCodeRelationshipFunc: func(ctx context.Context, instanceID string, codeListID string, code string) error {
 			return nil
 		},
-		InsertDimensionFunc: func(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
+		InsertDimensionFunc: func(ctx context.Context, cache map[string]string, cacheMutex *sync.Mutex, instanceID string, dimension *models.Dimension) (*models.Dimension, error) {
 			return dimension, nil
 		},
 		CreateInstanceConstraintFunc: func(ctx context.Context, instanceID string) error {

--- a/store/store.go
+++ b/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"sync"
 
 	"github.com/ONSdigital/dp-graph/v2/models"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -16,7 +17,7 @@ type Storer interface {
 	AddDimensions(ctx context.Context, instanceID string, dimensions []interface{}) error
 	CreateCodeRelationship(ctx context.Context, instanceID, codeListID, code string) error
 	InstanceExists(ctx context.Context, instanceID string) (bool, error)
-	InsertDimension(ctx context.Context, cache map[string]string, instanceID string, dimension *models.Dimension) (*models.Dimension, error)
+	InsertDimension(ctx context.Context, cache map[string]string, cacheMutex *sync.Mutex, instanceID string, dimension *models.Dimension) (*models.Dimension, error)
 	GetCodesOrder(ctx context.Context, codeListID string, codes []string) (codeOrders map[string]*int, err error)
 	Checker(ctx context.Context, state *healthcheck.CheckState) error
 	Close(ctx context.Context) error


### PR DESCRIPTION
### What

- Use the latest `dp-graph` with cache concurrency issues fix.
- create and provide a cache mutex to dp-graph for InsertDimensions

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone
