### PR TITLE
Fix/dp kafka v2.4.3

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,7 @@ func getDefaultConfig() *Config {
 		BindAddr:         ":23000",
 		ServiceAuthToken: "4424A9F2-B903-40F4-85F1-240107D1AFAF",
 		KafkaConfig: KafkaConfig{
-			Brokers:                        []string{"localhost:9092"},
+			Brokers:                        []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 			BatchSize:                      1, //not all implementations will allow for batching, so set to a safe default
 			NumWorkers:                     1,
 			Version:                        "1.0.2",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,7 +24,7 @@ func TestGet(t *testing.T) {
 				Convey("And values should be set to the expected defaults", func() {
 					So(cfg.BindAddr, ShouldEqual, ":23000")
 					So(cfg.ServiceAuthToken, ShouldEqual, "Bearer 4424A9F2-B903-40F4-85F1-240107D1AFAF")
-					So(cfg.KafkaConfig.Brokers[0], ShouldEqual, "localhost:9092")
+					So(cfg.KafkaConfig.Brokers, ShouldResemble, []string{"localhost:9092", "localhost:9093", "localhost:9094"})
 					So(cfg.KafkaConfig.BatchSize, ShouldEqual, 1)
 					So(cfg.KafkaConfig.NumWorkers, ShouldEqual, 1)
 					So(cfg.KafkaConfig.OffsetOldest, ShouldEqual, true)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.3.0
 	github.com/ONSdigital/dp-graph/v2 v2.15.0
 	github.com/ONSdigital/dp-healthcheck v1.1.2
-	github.com/ONSdigital/dp-kafka/v2 v2.4.1
+	github.com/ONSdigital/dp-kafka/v2 v2.4.3
 	github.com/ONSdigital/dp-net v1.2.0
 	github.com/ONSdigital/dp-reporter-client v1.1.0
 	github.com/ONSdigital/go-ns v0.0.0-20210831102424-ebdecc20fe9e // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/ONSdigital/dp-healthcheck v1.1.0/go.mod h1:vZwyjMJiCHjp/sJ2R1ZEqzZT0r
 github.com/ONSdigital/dp-healthcheck v1.1.2 h1:IE4G9/jGLLBoQo8DOdPdmrD3igVfmTEWe7dryg+BI98=
 github.com/ONSdigital/dp-healthcheck v1.1.2/go.mod h1:NhfezqsFUBufxaN8w+b0eF5Ps4i1K1ikAw7ITKjyAuc=
 github.com/ONSdigital/dp-kafka/v2 v2.0.2/go.mod h1:iyDeWxp1QyJJBQ4cOCWuwrwU9iGS9qYbfV7avbcaenI=
-github.com/ONSdigital/dp-kafka/v2 v2.4.1 h1:e4nTpfsqb/gRRF3ZgstZ8mEjONvt+QPoWKbZoRg5dU8=
-github.com/ONSdigital/dp-kafka/v2 v2.4.1/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3 h1:Sb5nc4M3RsDMDmclsTqyjTMP6IBD7dRkv3kaIM26LLs=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=


### PR DESCRIPTION
### What

- Upgrade `dp-kafka` dependency to v2.4.3 to use the healthcheck fix where kafka producers/consumers will have a `warning` health (instead of `critical`) if enough brokers are available
  - min 2 brokers for producers
  - min 1 broker for consumers
- kafkaAddr match brokers in dp-compose

### How to review

Make sure `dp-kafka` dependency is upgraded

### Who can review

anyone